### PR TITLE
de-Running-a-Server: fix fast.com hyperlink

### DIFF
--- a/wiki/de/de-Running-a-Server.md
+++ b/wiki/de/de-Running-a-Server.md
@@ -40,7 +40,7 @@ Sobald alle Probleme mit den Musikern auf diese Weise gelöst sind, kannst du te
 
 ### Bandbreite – hast du genug?
 
-Ein typischer Jam mit 4 Personen könnte grob 200Kbps * 4 = 800Kbs (0.8Mbps) Upload und Download benötigen. Eine typische Breitbandverbindung mit 10MBit/s Download und 1MBit/s Upload, **wird sehr wahrscheinlich ab dem fünften Musiker zu gering sein**, insbesondere wenn andere Musiker Einstellungen wählen, die viel Bandbreite benötigen. Hier kannst du testen, [überprüfen, wie viel Bandbreite dein Anschluss bietet] (https://fast.com). [Mehr über die benötigte Bandbreite](Network-Requirements) bei verschiedenen Qualitätseinstellungen.
+Ein typischer Jam mit 4 Personen könnte grob 200Kbps * 4 = 800Kbs (0.8Mbps) Upload und Download benötigen. Eine typische Breitbandverbindung mit 10MBit/s Download und 1MBit/s Upload, **wird sehr wahrscheinlich ab dem fünften Musiker zu gering sein**, insbesondere wenn andere Musiker Einstellungen wählen, die viel Bandbreite benötigen. Hier kannst du testen, [wie viel Bandbreite dein Anschluss bietet](https://fast.com). [Mehr über die benötigte Bandbreite](Network-Requirements) bei verschiedenen Qualitätseinstellungen.
 
 ### Allgemein
 


### PR DESCRIPTION
This PR fixes bad wiki markup (regarding the fast.com link) and a duplicate word in de-Running-a-Server.md.