### PR TITLE
[en] consistency: Internet speed not clear: MBit/s, Mbps,...

### DIFF
--- a/wiki/en/en-Getting-Started.md
+++ b/wiki/en/en-Getting-Started.md
@@ -62,5 +62,5 @@ Further information about how to avoid listening to yourself (and help with othe
 _Jamulus works on the client server principle. Everybody’s audio is sent to a server, mixed and processed there. Afterwards the audio is sent to every client. If a server is made public and registered on a central server, its information will be broadcasted to all clients._
 
 ## Footnotes
-[^1]: [Full details here](Network-Requirements){: target="_blank" rel="noopener noreferrer"}. If you have 10Mbits down and 1Mbps up, you're unlikely to run into bandwidth-related issues.
+[^1]: [Full details here](Network-Requirements){: target="_blank" rel="noopener noreferrer"}. If you have 10MBit/s down and 1MBit/s up, you're unlikely to run into bandwidth-related issues.
 [^2]: Bluetooth headphones usually have too much latency. That's one reason why wired headphones are required. Particularity if singing or playing acoustic instruments to make sure you keep in time with others only use headphones (see the [note on this](Getting-Started#having-trouble-cant-keep-in-time) for further information).

--- a/wiki/en/en-Getting-Started.md
+++ b/wiki/en/en-Getting-Started.md
@@ -62,5 +62,5 @@ Further information about how to avoid listening to yourself (and help with othe
 _Jamulus works on the client server principle. Everybody’s audio is sent to a server, mixed and processed there. Afterwards the audio is sent to every client. If a server is made public and registered on a central server, its information will be broadcasted to all clients._
 
 ## Footnotes
-[^1]: [Full details here](Network-Requirements){: target="_blank" rel="noopener noreferrer"}. If you have 10MBit/s down and 1MBit/s up, you're unlikely to run into bandwidth-related issues.
+[^1]: [Full details here](Network-Requirements){: target="_blank" rel="noopener noreferrer"}. If you have 10Mbit/s down and 1Mbit/s up, you're unlikely to run into bandwidth-related issues.
 [^2]: Bluetooth headphones usually have too much latency. That's one reason why wired headphones are required. Particularity if singing or playing acoustic instruments to make sure you keep in time with others only use headphones (see the [note on this](Getting-Started#having-trouble-cant-keep-in-time) for further information).

--- a/wiki/en/en-Getting-Started.md
+++ b/wiki/en/en-Getting-Started.md
@@ -62,5 +62,5 @@ Further information about how to avoid listening to yourself (and help with othe
 _Jamulus works on the client server principle. Everybody’s audio is sent to a server, mixed and processed there. Afterwards the audio is sent to every client. If a server is made public and registered on a central server, its information will be broadcasted to all clients._
 
 ## Footnotes
-[^1]: [Full details here](Network-Requirements){: target="_blank" rel="noopener noreferrer"}. If you have 10Mbit/s down and 1Mbit/s up, you're unlikely to run into bandwidth-related issues.
+[^1]: [Full details here](Network-Requirements){: target="_blank" rel="noopener noreferrer"}. If you have 10 Mbit/s down and 1 Mbit/s up, you're unlikely to run into bandwidth-related issues.
 [^2]: Bluetooth headphones usually have too much latency. That's one reason why wired headphones are required. Particularity if singing or playing acoustic instruments to make sure you keep in time with others only use headphones (see the [note on this](Getting-Started#having-trouble-cant-keep-in-time) for further information).

--- a/wiki/en/en-Hardware-Setup.md
+++ b/wiki/en/en-Hardware-Setup.md
@@ -71,7 +71,7 @@ _(Thanks to [pcar75](https://github.com/pcar75) for this information)_
 
 ## Other examples
 
-**This video documents a [live jam session](https://youtu.be/c8838jS2g3U).** I am using a Lexicon Omega USB audio card on a 2009 Mac Mini. My bandmates all use Windows 10 and have Behringer audio cards, e.g. the Behringer Xenyx 1204USB. My internet connection is 10 Mbps down / 1 Mbps upstream via DSL.
+**This video documents a [live jam session](https://youtu.be/c8838jS2g3U).** I am using a Lexicon Omega USB audio card on a 2009 Mac Mini. My bandmates all use Windows 10 and have Behringer audio cards, e.g. the Behringer Xenyx 1204USB. My internet connection is 10 Mbit/s down / 1 Mbit/s upstream via DSL.
 
 **Jamulus user [Andrew Evans](https://sourceforge.net/u/belvario/profile/)**: With bandmates all within one city (but spanning 2 ISPs) and achieving consistent 20ms ping time, running the server on a separate dedicated Windows machine and a client on a MacBook Pro. Remote players on MacBook Air. Everyone on wired Ethernet connections to their home router/gateways. We used WhatsApp video to see each other (with audio muted - it's funny to see how far behind the WhatsApp audio lags from Jamulus though!)
 

--- a/wiki/en/en-Network-Requirements.md
+++ b/wiki/en/en-Network-Requirements.md
@@ -33,4 +33,4 @@ With the following units
 There is one upstream (musician sending to the server) and one downstream (server sending back the mix to the musician)
 ![image](https://user-images.githubusercontent.com/9976944/79274940-999b0b00-7ea5-11ea-85be-3ded5ee198d5.png)
 
-Note also that mean ADSL2 transfer rate is 10 Mbits/second for downstream and 1 Mbit/second for upstream. The actual performance depends on distance to the provider, which may [theoretically range from 24Mb/s at 0.3km to 1.5Mb/s at 5.2km](https://en.wikipedia.org/wiki/Asymmetric_digital_subscriber_line) for download rate.
+Note also that mean ADSL2 transfer rate is 10 MBit/s for downstream and 1 MBit/s for upstream. The actual performance depends on distance to the provider, which may [theoretically range from 24MBit/s at 0.3km to 1.5MBit/s at 5.2km](https://en.wikipedia.org/wiki/Asymmetric_digital_subscriber_line) for download rate.

--- a/wiki/en/en-Network-Requirements.md
+++ b/wiki/en/en-Network-Requirements.md
@@ -16,21 +16,21 @@ The audio settings have an impact on the required network bandwidth. The below t
 
 With the following units
 * ms : milliseconds
-* Kbps : Kilo-bits per seconds (Reminder : 1Mbps = 1024Kbps, 1KByte = 8Kbits)
-* Mbps : Mega-bits per seconds
+* Kbit/s : Kilo-bits per seconds (Reminder : 1Mbit/s = 1024Kbit/s, 1KByte = 8Kbits)
+* Mbit/s : Mega-bits per seconds
 
 | Channels  | Quality | Bandwidth (for buffer : 2.67ms) |  Bandwidth (for buffer : 5.33ms) | Bandwidth (for buffer : 10.67ms) | Bandwidth (for buffer : 21.33ms) |
 | --------- | ------ | -------- | -------- | -------- | -------- |
-| Stereo    | High   | 894 Kbps | 657 Kbps | 541 Kbps | 483 Kbps |
-| Stereo    | Medium | 672 Kbps | 444 Kbps | 328 Kbps | 270 Kbps |
-| Stereo    | Low    | 606 Kbps | 372 Kbps | 256 Kbps | 198 Kbps |
-| Mono      | High   | 672 Kbps | 444 Kbps | 328 Kbps | 270 Kbps |
-| Mono      | Medium | 594 Kbps | 366 Kbps | 250 Kbps | 192 Kbps |
-| Mono      | Low    | 534 Kbps | 306 Kbps | 190 Kbps | 132 Kbps |
+| Stereo    | High   | 894 Kbit/s | 657 Kbit/s | 541 Kbit/s | 483 Kbit/s |
+| Stereo    | Medium | 672 Kbit/s | 444 Kbit/s | 328 Kbit/s | 270 Kbit/s |
+| Stereo    | Low    | 606 Kbit/s | 372 Kbit/s | 256 Kbit/s | 198 Kbit/s |
+| Mono      | High   | 672 Kbit/s | 444 Kbit/s | 328 Kbit/s | 270 Kbit/s |
+| Mono      | Medium | 594 Kbit/s | 366 Kbit/s | 250 Kbit/s | 192 Kbit/s |
+| Mono      | Low    | 534 Kbit/s | 306 Kbit/s | 190 Kbit/s | 132 Kbit/s |
 
 ## Network bandwidth
 
 There is one upstream (musician sending to the server) and one downstream (server sending back the mix to the musician)
 ![image](https://user-images.githubusercontent.com/9976944/79274940-999b0b00-7ea5-11ea-85be-3ded5ee198d5.png)
 
-Note also that mean ADSL2 transfer rate is 10 MBit/s for downstream and 1 MBit/s for upstream. The actual performance depends on distance to the provider, which may [theoretically range from 24MBit/s at 0.3km to 1.5MBit/s at 5.2km](https://en.wikipedia.org/wiki/Asymmetric_digital_subscriber_line) for download rate.
+Note also that mean ADSL2 transfer rate is 10 Mbit/s for downstream and 1 Mbit/s for upstream. The actual performance depends on distance to the provider, which may [theoretically range from 24Mbit/s at 0.3km to 1.5Mbit/s at 5.2km](https://en.wikipedia.org/wiki/Asymmetric_digital_subscriber_line) for download rate.

--- a/wiki/en/en-Network-Requirements.md
+++ b/wiki/en/en-Network-Requirements.md
@@ -16,10 +16,10 @@ The audio settings have an impact on the required network bandwidth. The below t
 
 With the following units
 * ms : milliseconds
-* Kbit/s : Kilo-bits per seconds (Reminder : 1Mbit/s = 1024Kbit/s, 1KByte = 8Kbits)
+* Kbit/s : Kilo-bits per seconds (Reminder : 1 Mbit/s = 1024 Kbit/s, 1 KByte = 8 Kbit/s)
 * Mbit/s : Mega-bits per seconds
 
-| Channels  | Quality | Bandwidth (for buffer : 2.67ms) |  Bandwidth (for buffer : 5.33ms) | Bandwidth (for buffer : 10.67ms) | Bandwidth (for buffer : 21.33ms) |
+| Channels  | Quality | Bandwidth (for buffer : 2.67 ms) |  Bandwidth (for buffer : 5.33ms) | Bandwidth (for buffer : 10.67 ms) | Bandwidth (for buffer : 21.33 ms) |
 | --------- | ------ | -------- | -------- | -------- | -------- |
 | Stereo    | High   | 894 Kbit/s | 657 Kbit/s | 541 Kbit/s | 483 Kbit/s |
 | Stereo    | Medium | 672 Kbit/s | 444 Kbit/s | 328 Kbit/s | 270 Kbit/s |
@@ -33,4 +33,4 @@ With the following units
 There is one upstream (musician sending to the server) and one downstream (server sending back the mix to the musician)
 ![image](https://user-images.githubusercontent.com/9976944/79274940-999b0b00-7ea5-11ea-85be-3ded5ee198d5.png)
 
-Note also that mean ADSL2 transfer rate is 10 Mbit/s for downstream and 1 Mbit/s for upstream. The actual performance depends on distance to the provider, which may [theoretically range from 24Mbit/s at 0.3km to 1.5Mbit/s at 5.2km](https://en.wikipedia.org/wiki/Asymmetric_digital_subscriber_line) for download rate.
+Note also that mean ADSL2 transfer rate is 10 Mbit/s for downstream and 1 Mbit/s for upstream. The actual performance depends on distance to the provider, which may [theoretically range from 24 Mbit/s at 0.3km to 1.5 Mbit/s at 5.2km](https://en.wikipedia.org/wiki/Asymmetric_digital_subscriber_line) for download rate.

--- a/wiki/en/en-Network-Requirements.md
+++ b/wiki/en/en-Network-Requirements.md
@@ -12,11 +12,11 @@ permalink: "/wiki/Network-Requirements"
 The audio settings have an impact on the required network bandwidth. The below table summarizes the network requirements with respect to the configuration of:
 * channels : stereo/mono
 * quality : high/medium/low
-* audio buffer duration : 2.67ms, 5.33ms, 10.67ms, 21.33ms
+* audio buffer duration : 2.67 ms, 5.33 ms, 10.67 ms, 21.33 ms
 
 With the following units
 * ms : milliseconds
-* Kbit/s : Kilo-bits per seconds (Reminder : 1 Mbit/s = 1024 Kbit/s, 1 KByte = 8 Kbit/s)
+* Kbit/s : Kilo-bits per seconds (Reminder : 1 Mbit/s = 1024 Kbit/s, 1 KByte/s = 8 Kbit/s)
 * Mbit/s : Mega-bits per seconds
 
 | Channels  | Quality | Bandwidth (for buffer : 2.67 ms) |  Bandwidth (for buffer : 5.33ms) | Bandwidth (for buffer : 10.67 ms) | Bandwidth (for buffer : 21.33 ms) |

--- a/wiki/en/en-Running-a-Server.md
+++ b/wiki/en/en-Running-a-Server.md
@@ -39,7 +39,7 @@ Once any issues with musicians have been solved in this way, you can then invest
 
 ### Bandwidth – do you have enough?
 
-A typical jam might have 4 people, for which you would need 200Kbit/s * 4 = 800Kbit/s (0.8 Mbit/s) up and down. So if you have a 10 Mbit/s down and 1 Mbit/s up broadband connection, **you may start running out of bandwidth if a fifth player joins**, particularly if other musicians choose settings that increase their usage. You may want to [check that you have enough speed](https://fast.com) for that. [Read more about bandwidth use](Network-Requirements) at different quality settings.
+A typical jam might have 4 people, for which you would need 200 Kbit/s * 4 = 800 Kbit/s (0.8 Mbit/s) up and down. So if you have a 10 Mbit/s down and 1 Mbit/s up broadband connection, **you may start running out of bandwidth if a fifth player joins**, particularly if other musicians choose settings that increase their usage. You may want to [check that you have enough speed](https://fast.com) for that. [Read more about bandwidth use](Network-Requirements) at different quality settings.
 
 ### In general
 

--- a/wiki/en/en-Running-a-Server.md
+++ b/wiki/en/en-Running-a-Server.md
@@ -39,7 +39,7 @@ Once any issues with musicians have been solved in this way, you can then invest
 
 ### Bandwidth – do you have enough?
 
-A typical jam might have 4 people, for which you would need 200Kbps * 4 = 800Kbs (0.8Mbps) up and down. So if you have a 10Mbits down and 1Mbps up broadband connection, **you may start running out of bandwidth if a fifth player joins**, particularly if other musicians choose settings that increase their usage. You may want to [check that you have enough speed](https://fast.com) for that. [Read more about bandwidth use](Network-Requirements) at different quality settings.
+A typical jam might have 4 people, for which you would need 200Kbit/s * 4 = 800Kbit/s (0.8 Mbit/s) up and down. So if you have a 10 Mbit/s down and 1 Mbit/s up broadband connection, **you may start running out of bandwidth if a fifth player joins**, particularly if other musicians choose settings that increase their usage. You may want to [check that you have enough speed](https://fast.com) for that. [Read more about bandwidth use](Network-Requirements) at different quality settings.
 
 ### In general
 


### PR DESCRIPTION
Currently in the wiki there are multiple ways expressing internet bandwidth. This PR (and the mbit branch) should try to discuss and fix a few of these inconsistencies. 

In German we usually use MBit/s but I'm not sure if this is also the case in English. @gilgongo should comment on that.