### PR TITLE
[en] consistency alsa -> ALSA (2020-11-24-Multiple-Audio-Interfaces.md)

### DIFF
--- a/_posts/2020-11-24-Multiple-Audio-Interfaces.md
+++ b/_posts/2020-11-24-Multiple-Audio-Interfaces.md
@@ -46,7 +46,7 @@ On Linux, it is possible to route additional devices to JACK by using alsa_in.
 **Requirements:**
 
 * QjackCtl
-* alsa
+* ALSA
 
 **Steps:**
 1. Follow [this tutorial](https://www.penguinproducer.com/Blog/2011/11/using-multiple-devices-with-jack/) to route the desired interface into JACK by using alsa_in.


### PR DESCRIPTION
ALSA is an acronym for Advanced Linux Sound Architecture.
Hence it should always be written capitalised.