### PR TITLE
Breadcrumb

### DIFF
--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -8,4 +8,7 @@
  {% if include.branch2 %}
    &gt; <a href="{{ include.branch2-url }}">{{ include.branch2 }}</a>
  {% endif %}
+  {% if include.branch3 %}
+   &gt; <a href="{{ include.branch3-url }}">{{ include.branch3 }}</a>
+ {% endif %}
 </div>

--- a/_includes/breadcrumb.html
+++ b/_includes/breadcrumb.html
@@ -1,0 +1,11 @@
+<div id="breadcrumb">
+ {% if include.root %}
+   <strong>{{ include.root }}</strong> |   
+ {% endif %}
+ {% if include.branch1 %}
+   <a href="{{ include.branch1-url }}">{{ include.branch1 }}</a> 
+ {% endif %}
+ {% if include.branch2 %}
+   &gt; <a href="{{ include.branch2-url }}">{{ include.branch2 }}</a>
+ {% endif %}
+</div>

--- a/assets/css/wiki.css
+++ b/assets/css/wiki.css
@@ -29,6 +29,11 @@
   padding: 20px;
 }
 
+.wikisite #breadcrumb {
+  line-height: 90%;
+  font-size: 0.90em;
+}
+
 .wikisite .button-container {
     margin: .25em 0;
 }

--- a/wiki/en/en-Central-Servers.md
+++ b/wiki/en/en-Central-Servers.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Central-Servers"
 ---
 
+{% include breadcrumb.html root="More" branch1="Running a Server" branch1-url="Running-a-Server" %}
+
 # Public Server Registration
 
 Because there is a limit of 150 servers per central server, you need to select which central server you want to advertise your server on. Select a genre if you intend to limit players to that style (players can then see your server in their genre list). 

--- a/wiki/en/en-Choosing-a-Server-Type.md
+++ b/wiki/en/en-Choosing-a-Server-Type.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Choosing-a-Server-Type"
 ---
 
+{% include breadcrumb.html root="More" branch1="Running a Server" branch1-url="Running-a-Server" %}
+
 # Server Types
 
 You can run your server in one of three "modes" (either at home or on a 3rd party host):

--- a/wiki/en/en-Hardware-Setup.md
+++ b/wiki/en/en-Hardware-Setup.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Hardware-Setup"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Getting Started" branch1-url="Getting-Started" %}
+
 # Hardware Setup
 
 ## General info

--- a/wiki/en/en-Installation-for-Linux.md
+++ b/wiki/en/en-Installation-for-Linux.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Installation-for-Linux"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Getting Started" branch1-url="Getting-Started" %}
+
 # Installation for Linux
 Make sure you read the [Getting Started](Getting-Started) page.
 

--- a/wiki/en/en-Installation-for-Macintosh.md
+++ b/wiki/en/en-Installation-for-Macintosh.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Installation-for-Macintosh"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Getting Started" branch1-url="Getting-Started" %}
+
 # Installation for macOS
 
 Make sure you've already read the [Getting Started](Getting-Started) page.

--- a/wiki/en/en-Installation-for-Windows.md
+++ b/wiki/en/en-Installation-for-Windows.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Installation-for-Windows"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Getting Started" branch1-url="Getting-Started" %}
+
 # Installation for Windows
 Make sure you read the [Getting Started](Getting-Started) page.
 1. **Download and install an ASIO Driver**. It is recommended to use a sound card/interface with a native ASIO driver. If you don't have an external sound card, you probably need to install [this free ASIO driver (ASIO4ALL)](https://www.asio4all.org){: target="_blank" rel="noopener noreferrer"} before installing Jamulus.

--- a/wiki/en/en-Running-a-Private-Server.md
+++ b/wiki/en/en-Running-a-Private-Server.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Running-a-Private-Server"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Running a Server" branch1-url="Running-a-Server" %}
+
 # Running a Private Server
 
 **_Please ensure you have read the [server overview](Running-a-Server)_**

--- a/wiki/en/en-Server-Linux.md
+++ b/wiki/en/en-Server-Linux.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Server-Linux"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Running a Server" branch1-url="Running-a-Server" %}
+
 # Server Installation - Linux
 
 

--- a/wiki/en/en-Server-Troubleshooting.md
+++ b/wiki/en/en-Server-Troubleshooting.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Server-Troubleshooting"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Running a Server" branch1-url="Running-a-Server" %}
+
 # Troubleshooting
 
 ## Servers - Public

--- a/wiki/en/en-Server-Win-Mac.md
+++ b/wiki/en/en-Server-Win-Mac.md
@@ -5,6 +5,8 @@ lang: "en"
 permalink: "/wiki/Server-Win-Mac"
 ---
 
+{% include breadcrumb.html root="Using Jamulus" branch1="Running a Server" branch1-url="Running-a-Server" %}
+
 # Installation for Windows and macOS
 
 


### PR DESCRIPTION
Setting up a breadcrumb include file (see https://github.com/jamulussoftware/jamuluswebsite/issues/9).  Put this above the H1 when needed, for example:

`{% include breadcrumb.html root="Using Jamulus" branch1="Getting Started" branch1-url="Getting-Started" %}`

I think this will do the job. I can put them on the relevant pages (on this branch?) now if so.