### PR TITLE
Privacy Statement: Remove obsolete CloudFlare reference

### DIFF
--- a/wiki/en/en-Privacy-Statement.md
+++ b/wiki/en/en-Privacy-Statement.md
@@ -22,9 +22,7 @@ When you connect to a public server, your profile is also available to third par
 
 When you connect to a public or private server, the server operator can see your IP address while you are connected.  If the server operator has enabled logging (which is off by default) your IP address will also be logged and stored in the server's log file.
 
-As a server operator, when you register a public server with a Central Server, your IP address is sent to CloudFlare (1.1.1.1) in order to identify your public IP address. The IP addresses of all public servers registered with the Central Server can also be seen by third parties for informational or other purposes (for example [here](https://explorer.jamulus.io/)). Your public IP address is otherwise not logged or stored by Jamulus, but may be stored or processed by third parties.
-
-_Users concerned by the use of CloudFlare's network can [re-compile](Compiling) the Jamulus source code to use an alternative for WELL_KNOWN_HOST/ WELL_KNOWN_PORT in [global.h](https://github.com/jamulussoftware/jamulus/blob/master/src/global.h#L111)_
+The IP addresses of all public servers registered with the Central Server can also be seen by third parties for informational or other purposes (for example [here](https://explorer.jamulus.io/)). Your public IP address is otherwise not logged or stored by Jamulus, but may be stored or processed by third parties.
 
 ### Audio Recordings
 

--- a/wiki/es/es-Privacy-Statement.md
+++ b/wiki/es/es-Privacy-Statement.md
@@ -22,9 +22,7 @@ Cuando te conectas a un servidor público, tu perfil también es accesible por p
 
 Cuando te conectas a un servidor público o privado, el operador del servidor puede ver tu dirección IP mientras dure tu conexión. Si el operador del servidor ha habilitado el registro (que está deshabilitado por defecto) tu dirección IP será registrado y guardado en el archivo de registro del servidor.
 
-Como operador de un servidor, cuando tu registras un servidor público con un Servidor Central, tu dirección IP es enviada a CloudFare (1.1.1.1) para identificar tu dirección IP pública. Las direcciones IP de todos los servidores públicos registrados con el Servidor Central también pueden ser vistas por terceros para fines informativos u otros fines (por ejemplo [aquí](https://explorer.jamulus.io/)). Tu dirección IP pública no es registrada ni guardada por parte de Jamulus, pero puede ser guardada o procesada por terceros.
-
-_Los usuarios preocupados por el uso de la red de CloudFare pueden [re-compilar](Compiling) el código fuente de Jamulus para utilizar una alternativa para WELL_KNOWN_HOST/ WELL_KNOWN_PORT en [global.h](https://github.com/jamulussoftware/jamulus/blob/master/src/global.h#L111)_
+Las direcciones IP de todos los servidores públicos registrados con el Servidor Central también pueden ser vistas por terceros para fines informativos u otros fines (por ejemplo [aquí](https://explorer.jamulus.io/)). Tu dirección IP pública no es registrada ni guardada por parte de Jamulus, pero puede ser guardada o procesada por terceros.
 
 ### Grabaciones de Audio
 

--- a/wiki/fr/fr-Client-Troubleshooting.md
+++ b/wiki/fr/fr-Client-Troubleshooting.md
@@ -50,7 +50,7 @@ Vous pouvez régler votre « Niveau de nouveau client » sur une valeur faible
 
 ### Vous ne voyez pas le serveur que vous voulez rejoindre ?
 
-Vérifiez d'abord que vous avez le bon serveur de genre musical sélectionné dans votre fenêtre des paramètres de connexion. Mais il arrive parfois que des problèmes de réseau empêchent votre client d'afficher la liste de tous les serveurs disponibles. Si vous connaissez le nom du serveur que vous souhaitez rejoindre, vous pouvez [rechercher son adresse IP ici (en anglais)](http://explorer.jamulus.io/). Saisissez l'adresse IP dans le champ « Adresse du serveur » de la fenêtre « Paramètres de connexion » pour vous y connecter.
+Vérifiez d'abord que vous avez le bon serveur de genre musical sélectionné dans votre fenêtre des paramètres de connexion. Mais il arrive parfois que des problèmes de réseau empêchent votre client d'afficher la liste de tous les serveurs disponibles. Si vous connaissez le nom du serveur que vous souhaitez rejoindre, vous pouvez [rechercher son adresse IP ici (en anglais)](https://explorer.jamulus.io/). Saisissez l'adresse IP dans le champ « Adresse du serveur » de la fenêtre « Paramètres de connexion » pour vous y connecter.
 
 ### Vous ne voyez pas du tout la liste des serveurs ?
 

--- a/wiki/fr/fr-Privacy-Statement.md
+++ b/wiki/fr/fr-Privacy-Statement.md
@@ -24,9 +24,7 @@ Lorsque vous vous connectez à un serveur public, votre profil est également ac
 
 Lorsque vous vous connectez à un serveur public ou privé, l'administrateur du serveur peut voir votre adresse IP pendant que vous y êtes connecté. Si l'administrateur du serveur a activé la journalisation (qui est désactivée par défaut), votre adresse IP sera également journalisée et stockée dans le fichier journal du serveur.
 
-En tant qu'administrateur de serveur, lorsque vous inscrivez un serveur public auprès d'un serveur central, votre adresse IP est envoyée à CloudFlare (1.1.1.1) afin d'identifier votre adresse IP publique. Les adresses IP de tous les serveurs publics enregistrés auprès du serveur central peuvent également être consultées par des tiers à des fins d'information ou autres (par exemple [ici (en anglais)](http://explorer.jamulus.io/)). Votre adresse IP publique n'est par ailleurs pas journalisée ou stockée par Jamulus, mais peut être stockée ou traitée par des tiers.
-
-_Les utilisateurs concernés par l'utilisation du réseau CloudFlare peuvent [recompiler](Compiling) le code source de Jamulus afin d'utiliser une alternative pour WELL_KNOWN_HOST et WELL_KNOWN_PORT dans [global.h](https://github.com/corrados/jamulus/blob/master/src/global.h#L111)._
+Les adresses IP de tous les serveurs publics enregistrés auprès du serveur central peuvent également être consultées par des tiers à des fins d'information ou autres (par exemple [ici (en anglais)](http://explorer.jamulus.io/)). Votre adresse IP publique n'est par ailleurs pas journalisée ou stockée par Jamulus, mais peut être stockée ou traitée par des tiers.
 
 ### Enregistrements audio
 

--- a/wiki/fr/fr-Privacy-Statement.md
+++ b/wiki/fr/fr-Privacy-Statement.md
@@ -18,13 +18,13 @@ Nous ne plaçons pas de cookies de suivi, cependant SourceForge pourrait le fair
 
 Lorsque vous vous connectez à un serveur Jamulus public ou privé, tout ce que vous mettez dans Mon profil (dans les Paramètres) sera visible par les autres personnes sur ce serveur pendant que vous y serez connecté. Le serveur ne stocke ni ne sauvegarde par ailleurs les informations relatives à votre profil et l'administrateur du serveur n'y a pas accès sauf s'il y est également connecté en tant que client.
 
-Lorsque vous vous connectez à un serveur public, votre profil est également accessible aux tiers à partir du serveur central auquel ce serveur est inscrit. Ceci peut être à des fins d'information sur l'état du réseau public Jamulus (par exemple, [ici (en anglais)](http://explorer.jamulus.io/)), mais ne se limite pas à ça. Les informations relatives au profil ne sont pas journalisées ou stockées par le serveur Jamulus auquel vous êtes connecté, ou par le serveur central Jamulus, mais peuvent être stockées ou traitées par des tiers.
+Lorsque vous vous connectez à un serveur public, votre profil est également accessible aux tiers à partir du serveur central auquel ce serveur est inscrit. Ceci peut être à des fins d'information sur l'état du réseau public Jamulus (par exemple, [ici (en anglais)](https://explorer.jamulus.io/)), mais ne se limite pas à ça. Les informations relatives au profil ne sont pas journalisées ou stockées par le serveur Jamulus auquel vous êtes connecté, ou par le serveur central Jamulus, mais peuvent être stockées ou traitées par des tiers.
 
 ### Utilisation des adresses IP
 
 Lorsque vous vous connectez à un serveur public ou privé, l'administrateur du serveur peut voir votre adresse IP pendant que vous y êtes connecté. Si l'administrateur du serveur a activé la journalisation (qui est désactivée par défaut), votre adresse IP sera également journalisée et stockée dans le fichier journal du serveur.
 
-Les adresses IP de tous les serveurs publics enregistrés auprès du serveur central peuvent également être consultées par des tiers à des fins d'information ou autres (par exemple [ici (en anglais)](http://explorer.jamulus.io/)). Votre adresse IP publique n'est par ailleurs pas journalisée ou stockée par Jamulus, mais peut être stockée ou traitée par des tiers.
+Les adresses IP de tous les serveurs publics enregistrés auprès du serveur central peuvent également être consultées par des tiers à des fins d'information ou autres (par exemple [ici (en anglais)](https://explorer.jamulus.io/)). Votre adresse IP publique n'est par ailleurs pas journalisée ou stockée par Jamulus, mais peut être stockée ou traitée par des tiers.
 
 ### Enregistrements audio
 


### PR DESCRIPTION
Jamulus as of version 3.7.0 will no longer generate any traffic to CloudFlare. Therefore, remove the warnings from all translations of the Privacy Statement.

https://github.com/jamulussoftware/jamulus/issues/633
https://github.com/jamulussoftware/jamulus/pull/1092

This PR is against the release branch as it just removes text and does so for all languages which have versions of this document. @ann0see @gilgongo Can you please verify if this is correct?

Also, this PR should only be merged after translations are done in order to avoid getting any conflicts. If there are conflicts, it'll be easier to rebase this PR than to ask translators to fix stuff again. In my opinion this PR could still be merged before 3.7.1...?