### PR TITLE
Change SourceForge links to Github

### DIFF
--- a/_layouts/mainhomepage.html
+++ b/_layouts/mainhomepage.html
@@ -13,7 +13,7 @@
       "name": "Jamulus",
       "applicationCategory": "{{ page.ldjAppCategory }}",
       "operatingSystem": "Windows 10, macOS 10.11, Linux",
-      "discussionUrl": "https://sourceforge.net/p/llcon/discussion/",
+      "discussionUrl": "https://github.com/jamulussoftware/jamulus/discussions/",
       "license": "GPLv2",
       "creator": {
         "@type": "Person",
@@ -22,7 +22,7 @@
       "isAccessibleForFree": true,
       "alternateName": "llcon",
       "thumbnailUrl": "https://jamulus.io/assets/img/jamulus-icon-2020.svg",
-      "downloadUrl": "https://sourceforge.net/projects/llcon/files/latest/download",
+      "downloadUrl": "https://github.com/jamulussoftware/jamulus/releases/latest",
       "offers": {
         "@type": "Offer",
         "price": "0.00",

--- a/wiki/es/es-Installation-for-Windows.md
+++ b/wiki/es/es-Installation-for-Windows.md
@@ -12,7 +12,7 @@ Asegúrate de leer la página de [Cómo Empezar](Getting-Started).
 1. **Descarga e instala un driver ASIO**. Se recomienda usar una tarjeta de audio con driver ASIO nativo. Si no tienes una tarjeta de audio externa, probablemente tendrás que instalar un driver genérico como ASIO4ALL. Para más información, baja a la sección sobre [ASIO](#asio).
 1. [Descarga Jamulus]({{ site.download_root_link }}{{ site.download_file_names.windows }}){: .button}\\
 **Mirror 2:** [SourceForge](https://sourceforge.net/projects/llcon/files/latest/download)
-1. Instala Jamulus. Haz doble-clic en el instalador para ejecutarlo. Si ves un aviso de SmartScreen, haz clic en "Más info" y "Ejecutar de todas formas" para instalar Jamulus. (Si descargaste una versión nueva de Jamulus y eres de las primeras personas en descargarlo, Jamulus no entrará en la lista blanca de SmartScreen aún. No pagamos para la firma de código).
+1. **Instala Jamulus**. Haz doble-clic en el instalador para ejecutarlo. Si ves un aviso de SmartScreen, haz clic en "Más info" y "Ejecutar de todas formas" para instalar Jamulus. (Si descargaste una versión nueva de Jamulus y eres de las primeras personas en descargarlo, Jamulus no entrará en la lista blanca de SmartScreen aún. No pagamos para la firma de código).
 1. **Ejecuta Jamulus**. Ahora deberías de poder utilizar Jamulus igual que cualquier otra aplicación.
 1. **Configura tu tarjeta de sonido**. Una vez hecho, tienes que configurar tu hardware de audio. Mira cómo configurar ASIO4ALL si es lo que vas a utilizar y/o la [Configuración de Hardware](Hardware-Setup).
 

--- a/wiki/fr/fr-Client-Troubleshooting.md
+++ b/wiki/fr/fr-Client-Troubleshooting.md
@@ -8,7 +8,7 @@ permalink: "/wiki/Client-Troubleshooting"
 # Dépannage
 
 ### Vous n'entendez aucun son ou les autres ne vous entendent pas ?
-Commencez par les choses simples : assurez-vous que votre instrument ou micro et votre casque soient branchés sur les bonnes prises. Assurez-vous qu'aucune autre application comme votre navigateur, votre logiciel de vidéoconférence, etc. n'utilise votre carte son. Vous devriez les éteindre lorsque vous utilisez Jamulus. Si tout semble correct et que le problème persiste, il est probable qu'il y ait un problème avec les paramètres de votre périphérique son. Cela dépendra de votre configuration particulière (plate-forme, matériel, logiciel et pilotes), il est donc préférable de demander conseil sur [les forums (en anglais)](https://sourceforge.net/p/llcon/discussion/software/).
+Commencez par les choses simples : assurez-vous que votre instrument ou micro et votre casque soient branchés sur les bonnes prises. Assurez-vous qu'aucune autre application comme votre navigateur, votre logiciel de vidéoconférence, etc. n'utilise votre carte son. Vous devriez les éteindre lorsque vous utilisez Jamulus. Si tout semble correct et que le problème persiste, il est probable qu'il y ait un problème avec les paramètres de votre périphérique son. Cela dépendra de votre configuration particulière (plate-forme, matériel, logiciel et pilotes), il est donc préférable de demander conseil sur [les forums (en anglais)](https://github.com/jamulussoftware/jamulus/discussions/).
 
 **Utilisateurs de Windows (ASIO4All)** : si vous utilisez le pilote ASIO4All, consultez la [section de configuration ASIO4All](Installation-for-Windows#configuration-de-asio4all).
 
@@ -24,7 +24,7 @@ Vous pouvez testez si vous entendez correctement votre signal en procédant comm
 1. Fermez l'application d'enregistrement et lancez Jamulus. Vous ne devriez toujours pas vous entendre.
 1. Connectez-vous à un serveur et jouez quelque chose. Maintenant, vous devriez vous entendre avec le délai du serveur.
 
-**Si vous avez encore des problèmes**, essayez de demander sur le [forum du matériel (en anglais)](https://sourceforge.net/p/llcon/discussion/hardware/). La manière exacte dont vous éviterez d'écouter votre signal direct dépendra de votre configuration individuelle : votre interface son, votre console de mixage, l'endroit où est branché votre casque, etc… Par exemple, certaines interfaces audio ont des boutons « monitor » (désactivez-les), ou des options similaires.
+**Si vous avez encore des problèmes**, essayez de demander sur le [forum du matériel (en anglais)](https://github.com/jamulussoftware/jamulus/discussions/). La manière exacte dont vous éviterez d'écouter votre signal direct dépendra de votre configuration individuelle : votre interface son, votre console de mixage, l'endroit où est branché votre casque, etc… Par exemple, certaines interfaces audio ont des boutons « monitor » (désactivez-les), ou des options similaires.
 
 Sachez que si l'écoute du signal du serveur vous assure d'être synchronisé avec les autres musiciens, vous pourriez également rencontrer des problèmes si votre latence globale (indiquée par le voyant lumineux « Délai » dans Jamulus) n'est pas verte ou au moins jaune la plupart du temps. Consultez le [manuel du logiciel](Software-Manual) pour comprendre comment ajuster votre configuration afin de vous aider dans cette tâche.
 
@@ -72,4 +72,4 @@ Peut-être n'avez-vous pas répondu « oui » à la question `« Jamulus souhai
 
 ***
 
-Pour toute autre question, veuillez rechercher ou poster sur les [forums de discussion (en anglais)](https://sourceforge.net/p/llcon/discussion/software/).
+Pour toute autre question, veuillez rechercher ou poster sur les [forums de discussion (en anglais)](https://github.com/jamulussoftware/jamulus/discussions/).

--- a/wiki/fr/fr-Installation-for-Macintosh.md
+++ b/wiki/fr/fr-Installation-for-Macintosh.md
@@ -9,7 +9,7 @@ permalink: "/wiki/Installation-for-Macintosh"
 
 Assurez-vous d'avoir déjà lu la page [Premier pas](Getting-Started) avant de commencer.
 
-1. [Téléchargez Jamulus](https://sourceforge.net/projects/llcon/files/latest/download){: target="_blank" rel="noopener noreferrer" .button}
+1. [Téléchargez Jamulus](https://github.com/jamulussoftware/jamulus/releases/latest){: target="_blank" rel="noopener noreferrer" .button}
 1. **Décompressez le fichier .zip téléchargé**. Double-cliquez sur l'archive `.zip` pour la décompresser, un nouveau dossier du même nom sera créé. Ce dossier contient le fichier de licence et une image disque `.dmg` contenant l'application.
 1. **Double-cliquez sur le fichier `.dmg`** pour l'ouvrir l'image et vous verrez deux fichiers (client et serveur Jamulus). Acceptez la licence.
 1. **Glissez et déposez les deux icônes dans votre dossier Applications** pour installer Jamulus (client et serveur).

--- a/wiki/fr/fr-Installation-for-Windows.md
+++ b/wiki/fr/fr-Installation-for-Windows.md
@@ -10,7 +10,7 @@ permalink: "/wiki/Installation-for-Windows"
 Assurez-vous d'avoir déjà lu la page [Premier pas](Getting-Started).
 
 1. **Téléchargez et installez un pilote ASIO**. Il est recommandé d'utiliser une interface audio ou une carte son avec un pilote ASIO natif. Si vous n'en avez pas (en particulier pour les cartes son internes), installez ce [pilote ASIO gratuit (ASIO4All) (en anglais)](http://www.asio4all.org){: target="_blank" rel="noopener noreferrer"} avant d'installer Jamulus.
-1. [Téléchargez et installez Jamulus (en anglais)](https://sourceforge.net/projects/llcon/files/latest/download){: target="_blank" rel="noopener noreferrer"}. Si vous avez un avertissement de SmartScreen, cliquez sur « Plus d'infos » et « Exécuter quand même » pour installer Jamulus. C'est nécessaire car nous ne payons pas encore pour signer le code.
+1. [Téléchargez et installez Jamulus (en anglais)](https://github.com/jamulussoftware/jamulus/releases/latest){: target="_blank" rel="noopener noreferrer"}. Si vous avez un avertissement de SmartScreen, cliquez sur « Plus d'infos » et « Exécuter quand même » pour installer Jamulus. C'est nécessaire car nous ne payons pas encore pour signer le code.
 1. **Lancez Jamulus**. Vous devriez maintenant pouvoir utiliser Jamulus comme n'importe quelle autre application.
 1. **Configurez votre carte son**. Lorsque vous aurez fini, vous devrez configurer votre matériel audio. Regardez comment configurer ASIO4All si vous l'utilisez ([défilez vers le bas](#configuration-de-asio4all)), et consultez ensuite la [Configuration du matériel](Hardware-Setup).
 

--- a/wiki/it/it-Installation-for-Macintosh.md
+++ b/wiki/it/it-Installation-for-Macintosh.md
@@ -9,7 +9,7 @@ permalink: "/wiki/Installation-for-Macintosh"
 
 Assicurati di aver letto la pagina [Primi Passi](Getting-Started).
 
-1. [Scarica Jamulus](https://sourceforge.net/projects/llcon/files/latest/download){: target="_blank" rel="noopener noreferrer" .button}
+1. [Scarica Jamulus](https://github.com/jamulussoftware/jamulus/releases/latest){: target="_blank" rel="noopener noreferrer" .button}
 1. **Estrai il file zip scaricato.** Facendo doppio click sul file .zip, sarà creata una cartella con lo stesso nome del file scaricato. La cartella contiene il file della licenza e un file `.dmg` contenete l'applicazione.
 1. **Doppio click sul file `.dmg`** per aprirlo. Una volta aperto vedrete due applicazioni (il client e il server di Jamulus).
 1. **Trascina le due icone nella cartella delle Applicazioni** per installare Jamulus.

--- a/wiki/it/it-Installation-for-Windows.md
+++ b/wiki/it/it-Installation-for-Windows.md
@@ -10,7 +10,7 @@ permalink: "/wiki/Installation-for-Windows"
 Assicurati di aver letto la pagina [Primi Passi](Getting-Started).
 
 1. **Scarica e installa i driver ASIO**. Si raccomanda di usare una scheda audio con driver ASIO proprietario. In alternativa [installare i driver (ASIO4All)](http://www.asio4all.org){: target="_blank" rel="noopener noreferrer"} prima di installare Jamulus.
-1. **Scarica e installa Jamulus** dal sito [Jamulus](https://sourceforge.net/projects/llcon/files/latest/download){: target="_blank" rel="noopener noreferrer"}. Se ricevi un avviso, fai clic su "Ulteriori informazioni" e "Esegui comunque" per installare Jamulus.
+1. **Scarica e installa Jamulus** dal sito [Jamulus](https://github.com/jamulussoftware/jamulus/releases/latest){: target="_blank" rel="noopener noreferrer"}. Se ricevi un avviso, fai clic su "Ulteriori informazioni" e "Esegui comunque" per installare Jamulus.
 1. **Configura la tua scheda audio**. Dopo l'installazione passa a configurare il tuo hardware. Dai un'occhiata a come configurare i driver ASIO4All (scorri verso il basso), e poi su [Configurazione Hardware](Hardware-Setup).
 
 In alternativa puoi [compilare l'applicativo](Compiling) avendo le conoscenze necessarie.


### PR DESCRIPTION
This updates generic download or discussion links.
It keeps direct links to discussions on SourceForge.

Some installation documents have not been updated in all translations.
Those will link to Github only. The secondary location at Sourceforge will be linked once they are updated as part of the translation process.

This does not update the direct download links yet as this will be done as part of #359.
This does not update the page footer yet as more involved changes are planned as part of #345.