### PR TITLE
Start page: Add download links for 3.7.0

### DIFF
--- a/1-de-index.html
+++ b/1-de-index.html
@@ -10,7 +10,8 @@ metadescription: "Jamulus ist eine Open Source Software, die es Musikern erlaubt
 mAltProgIcon: "Jamulus Icon"
 mTSlogan: "Musiziere online. Mit deinen Freunden. Kostenlos."
 mTGetStartedNow: "Jetzt Starten!"
-mHTMLDownloadNow: 'Erweitert: <a href="https://sourceforge.net/projects/llcon/files/latest/download" target="_blank" id="dld_frm_sf" rel="noreferrer">sofort herunterladen</a>'
+mTDownloadNow: 'Sofort herunterladen für'
+mTOtherPlatforms: 'weitere Plattformen'
 ---
 <div class="fx-row fx-row-center-xs" id="firstrow">
   <div class="fx-col-100-xs">

--- a/1-es-index.html
+++ b/1-es-index.html
@@ -10,8 +10,8 @@ metadescription: "Jamulus es software de código abierto que permite a músicos 
 mAltProgIcon: "Jamulus icon" 
 mTSlogan: "Toca música online. Con amig@s. Gratis." 
 mTGetStartedNow: "¡Empieza ya!" 
-mHTMLDownloadNow: 'Avanzado: <a href="https://sourceforge.net/projects/llcon/files/latest/download" target="_blank" id="dld_frm_sf" 
-rel="noreferrer">descarga ahora</a>' 
+mTDownloadNow: 'Download now for'
+mTOtherPlatforms: 'other platforms'
 ---
 <div class="fx-row fx-row-center-xs" id="firstrow">
   <div class="fx-col-100-xs">

--- a/1-fr-index.html
+++ b/1-fr-index.html
@@ -10,7 +10,8 @@ metadescription: "Jamulus est un logiciel à source ouverte qui permet aux music
 mAltProgIcon: "Icône de Jamulus"
 mTSlogan: "Jouez de la musique en ligne. Avec vos amis. Librement et gratuitement."
 mTGetStartedNow: "Commencer maintenant&nbsp;!"
-mHTMLDownloadNow: 'Avancé&nbsp;: <a href="https://sourceforge.net/projects/llcon/files/latest/download" target="_blank" id="dld_frm_sf" rel="noreferrer">télécharger directement</a>'
+mTDownloadNow: 'Download now for'
+mTOtherPlatforms: 'other platforms'
 ---
 <div class="fx-row fx-row-center-xs" id="firstrow">
   <div class="fx-col-100-xs">

--- a/1-index.html
+++ b/1-index.html
@@ -10,7 +10,8 @@ metadescription: "Jamulus is open source software which enables musicians to per
 mAltProgIcon: "Jamulus icon"
 mTSlogan: "Play music online. With friends. For free."
 mTGetStartedNow: "Get started now!"
-mHTMLDownloadNow: 'Advanced: <a href="https://sourceforge.net/projects/llcon/files/latest/download" target="_blank" id="dld_frm_sf" rel="noreferrer">download now</a>'
+mTDownloadNow: 'Download now for'
+mTOtherPlatforms: 'other platforms'
 ---
 <div class="fx-row fx-row-center-xs" id="firstrow">
   <div class="fx-col-100-xs">

--- a/1-it-index.html
+++ b/1-it-index.html
@@ -10,7 +10,8 @@ metadescription: "Jamulus è un software opensource che permette ai musicisti di
 mAltProgIcon: "Jamulus icon"
 mTSlogan: "Suonare Online. Tra Amici. In libertà."
 mTGetStartedNow: "Comincia a Suonare!"
-mHTMLDownloadNow: 'Cominciamo: <a href="https://sourceforge.net/projects/llcon/files/latest/download" target="_blank" id="dld_frm_sf" rel="noreferrer">Scarica Ora</a>'
+mTDownloadNow: 'Download now for'
+mTOtherPlatforms: 'other platforms'
 ---
 <div class="fx-row fx-row-center-xs" id="firstrow">
   <div class="fx-col-100-xs">

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,7 @@ download_file_names:
   windows:                   "jamulus_3.7.0_win.exe"
   mac:                       "jamulus_3.7.0_mac.dmg"
   android:                   "jamulus_3.7.0_android.apk"
+download_overview_link:      "https://github.com/jamulussoftware/jamulus/releases/latest"
 
 githubrepoeditbase:          "https://github.com/jamulussoftware/jamuluswebsite/edit/changes"
 kbnewpage:                   'https://github.com/jamulussoftware/jamuluswebsite/new/changes/_posts/?value=---%0Alayout%3A%20post%0Atitle%3A%20%22Your%20Title%22%0Alang%3A%20%22en%22%0Aauthor%3A%20%22YourName%22%0Aheading%3A%20%22Heading%22%0A---%0AName%20this%20file%20and%20edit%20the%20parameters%20above%21&message=New%20post'

--- a/_layouts/mainhomepage.html
+++ b/_layouts/mainhomepage.html
@@ -45,7 +45,7 @@
           <a href="wiki/Getting-Started" id="get_started_btn_top">{{ page.mTGetStartedNow }}</a>
         </div>
         <div class="fx-col-100-xs" id="dl_frm_sf_container">
-          {{ page.mHTMLDownloadNow }}
+          {{ page.mTDownloadNow }} <a href="{{ site.download_root_link }}{{ site.download_file_names.windows }}" target="_blank" rel="noreferrer">Windows</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.mac }}" target="_blank" rel="noreferrer">Mac</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.deb-gui }}" target="_blank" rel="noreferrer">Debian/Ubuntu</a> or <a href="{{ site.download_overview_link }}" target="_blank" rel="noreferrer">{{{ page.mTOtherPlatforms }}</a>.'
         </div>
       </div>
     </div>

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -47,12 +47,12 @@ header {
   margin: .5em 0 0 0;
 }
 
-#dld_frm_sf {
+#dl_frm_sf_container a {
   color: #ffffff;
   text-decoration: none;
 }
 
-#dld_frm_sf:hover {
+#dl_frm_sf_container a:hover {
   text-decoration: underline;
 }
 
@@ -75,12 +75,12 @@ header {
   margin: .5em 0 0 0;
 }
 
-#dld_frm_sf {
+#dl_frm_sf_container a {
   color: #ffffff;
   text-decoration: none;
 }
 
-#dld_frm_sf:hover {
+#dl_frm_sf_container a:hover {
   text-decoration: underline;
 }
 

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -70,31 +70,3 @@ header {
   transition: 0.4s;
   opacity: 0.9;
 }
-
-#dl_frm_sf_container {
-  margin: .5em 0 0 0;
-}
-
-#dl_frm_sf_container a {
-  color: #ffffff;
-  text-decoration: none;
-}
-
-#dl_frm_sf_container a:hover {
-  text-decoration: underline;
-}
-
-#bannercontainer {
-  margin-top: 10px;
-}
-
-#jamulusbanner {
-  width: 100%;
-  transition: 0.4s;
-  opacity: 1;
-}
-
-#jamulusbanner:hover {
-  transition: 0.4s;
-  opacity: 0.9;
-}


### PR DESCRIPTION
Start page: Add download links for 3.7.0

This replaces the SourceForge link to platform-specific direct links on Github for better usability.
This requires text changes. To avoid delaying the release further, it was decided to not run those texts through translators again.
This could still be updated post-release, of course.

This required CSS changes because the styling was previously specified for a single link identified by an id=. This obviously breaks with multiple links.

Fixes #359.

This also cleans up the CSS which contained duplicate definitions.

**As variable expansion is not possible in front matter, the variables are reorganized.**

Might be easier to review if checking the two commits individually.