### PR TITLE
Start page: Fix download links for 3.7.0

### DIFF
--- a/_layouts/mainhomepage.html
+++ b/_layouts/mainhomepage.html
@@ -45,7 +45,7 @@
           <a href="wiki/Getting-Started" id="get_started_btn_top">{{ page.mTGetStartedNow }}</a>
         </div>
         <div class="fx-col-100-xs" id="dl_frm_sf_container">
-          {{ page.mTDownloadNow }} <a href="{{ site.download_root_link }}{{ site.download_file_names.windows }}" target="_blank" rel="noreferrer">Windows</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.mac }}" target="_blank" rel="noreferrer">Mac</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.deb-gui }}" target="_blank" rel="noreferrer">Debian/Ubuntu</a> or <a href="{{ site.download_overview_link }}" target="_blank" rel="noreferrer">{{{ page.mTOtherPlatforms }}</a>.'
+          {{ page.mTDownloadNow }} <a href="{{ site.download_root_link }}{{ site.download_file_names.windows }}" target="_blank" rel="noreferrer">Windows</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.mac }}" target="_blank" rel="noreferrer">Mac</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.deb-gui }}" target="_blank" rel="noreferrer">Debian/Ubuntu</a> or <a href="{{ site.download_overview_link }}" target="_blank" rel="noreferrer">{{ page.mTOtherPlatforms }}</a>.
         </div>
       </div>
     </div>


### PR DESCRIPTION
Bad Jekyll markup broke 'other platforms' link.