### PR TITLE
Update 2021-01-05-Jamulus-Sound-Devices.md

### DIFF
--- a/_posts/2021-01-05-Jamulus-Sound-Devices.md
+++ b/_posts/2021-01-05-Jamulus-Sound-Devices.md
@@ -218,11 +218,13 @@ Sounds great, can achieve 32 frame buffer and works on *Windows* and *Linux*.
 
 **[ZOOM LiveTrak L-8](https://zoomcorp.com/en/us/digital-mixer-multi-track-recorders/digital-mixer-recorder/LIVETRAK-L-8/)**, Mixer
 
-**Windows**: Latency is around 19ms (measured with local server with ping time of 0 ms) using "L-8 Driver" (ASIO, 07/02/2020) from [zoomcorp.com](https://zoomcorp.com/)
+**Windows**: Latency is around 19ms (measured with local server with ping time of 0 ms) using "L-8 Driver" (ASIO, 07/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads".
 
 **macOS**: Not yet tested
 
 **Linux**: Not yet tested
+
+***
 
 #### Amp modelers/effects pedals for instruments
 
@@ -260,11 +262,23 @@ Sounds great, can achieve 32 frame buffer and works on *Windows* and *Linux*.
 
 **[Zoom H2N](https://zoomcorp.com/en/us/handheld-recorders/handheld-recorders/h2n-handy-recorder/)**, USB portable recorder
 
-**Windows**: Latency is around 26ms (measured with local server with ping time of 0 ms) using "Stereo ASIO Driver" (06/02/2020) from [zoomcorp.com](https://zoomcorp.com/)
+**Windows**: Latency is around 26ms (measured with local server with ping time of 0 ms) using "Stereo ASIO Driver" (06/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads".
 
 **macOS**: Not yet tested
 
 **Linux**: Not yet tested
+
+***
+
+**[Zoom H2](https://zoomcorp.com/en/us/handheld-recorders/handheld-recorders/h2/)**, USB portable recorder
+
+**Windows**: Latency is around 26ms (measured with local server with ping time of 0 ms) using "Stereo ASIO Driver" (06/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads".
+
+**macOS**: Not yet tested
+
+**Linux**: Not yet tested
+
+***
 
 ### FireWire devices
 


### PR DESCRIPTION
Added ZOOM H2 as compatible device  and updated hints for drivers for ZOOM H2N & LiveTrak L-8