### PR TITLE
Update Fedora build dependency

### DIFF
--- a/wiki/en/en-Installation-for-Linux.md
+++ b/wiki/en/en-Installation-for-Linux.md
@@ -64,7 +64,7 @@ sudo apt-get install build-essential qt5-qmake qtdeclarative5-dev qt5-default qt
 On **Fedora**:
 
 ```shell
-sudo dnf install qt5-qtdeclarative-devel jack-audio-connection-kit-dbus libQt5Concurrent5 jack-audio-connection-kit-devel
+sudo dnf install qt5-qtdeclarative-devel jack-audio-connection-kit-dbus qt5-qtbase jack-audio-connection-kit-devel
 ```
 
 ### QjackCtl: Optional, but recommended


### PR DESCRIPTION
# Does this need translation?

- [x] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->

# Changes

Replaced the `libQt5Concurrent5` package (which is no longer available in Fedora) to `qt5-qtbase`, which provides the necessary libraries.
