### PR TITLE
Update 2021-01-05-Jamulus-Sound-Devices.md

### DIFF
--- a/_posts/2021-01-05-Jamulus-Sound-Devices.md
+++ b/_posts/2021-01-05-Jamulus-Sound-Devices.md
@@ -426,6 +426,18 @@ This device provides the **lowest latency**.
 
 See above. Not fully verified.
 
+***
+
+**[M-Audio Delta44/66/1010](https://www.sweetwater.com/store/detail/Delta44--m-audio-delta-44)**, PCI internal sound card with I/O breakout box
+
+**Windows**: ?
+
+**macOS**: ?
+
+**Linux**: Works great with jack.
+
+***
+
 ## Audio devices known not to work with Jamulus
 
 * **Zoom B3**, USB amplifier modeling pedal for bass. **Does not support 48 kHz**.


### PR DESCRIPTION
Added M-Audio PCI Delta 44/66/1010 series cards.

# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

Added M-Audio Delta 44/66/1010 series PCI sound cards.
