### PR TITLE
Add legacy build variable

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ download_file_names:
   deb-headless:              "jamulus_headless_3.7.0_ubuntu_amd64.deb"
   windows:                   "jamulus_3.7.0_win.exe"
   mac:                       "jamulus_3.7.0_mac.dmg"
+  mac-lagacy:                "jamulus_3_7_0_mac_legacy.dmg"
   android:                   "jamulus_3.7.0_android.apk"
 download_overview_link:      "https://github.com/jamulussoftware/jamulus/releases/latest"
 


### PR DESCRIPTION
Related to https://github.com/jamulussoftware/jamulus/pull/1768

# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

Add a variable to allow direct download of legacy builds. While strictly this doesn't require translations; we might need to add other buttons somewhere (for the legacy build).
