### PR TITLE
typo in Installation for Android

### DIFF
--- a/translator-files/po/fr/Installation-for-Android.po
+++ b/translator-files/po/fr/Installation-for-Android.po
@@ -14,6 +14,9 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Language: fr_FR\n"
+"X-Source-Language: C\n"
 
 #. type: YAML Front Matter: lang
 #: wiki/en/Installation-for-Android.md:1
@@ -42,11 +45,11 @@ msgstr "Installation pour Android"
 #. type: Plain text
 #: wiki/en/Installation-for-Android.md:9
 msgid ""
-"{% include breadcrumb.html root=\"Using Jamulus\" branch1=\"Getting Started"
-"\" branch1-url=\"Getting-Started\" %}"
+"{% include breadcrumb.html root=\"Using Jamulus\" branch1=\"Getting "
+"Started\" branch1-url=\"Getting-Started\" %}"
 msgstr ""
-"{% include breadcrumb.html root=\"Using Jamulus\" branch1=\"Getting Started"
-"\" branch1-url=\"Getting-Started\" %}"
+"{% include breadcrumb.html root=\"Using Jamulus\" branch1=\"Getting "
+"Started\" branch1-url=\"Getting-Started\" %}"
 
 #. type: Plain text
 #: wiki/en/Installation-for-Android.md:12
@@ -71,19 +74,19 @@ msgid ""
 "Although you **can** install Jamulus on Android devices (and hear sound), we "
 "strongly recommend **not** doing so. Sound quality - especially over WiFi - "
 "is usually bad and latency is high. If you have don't own a PC, we suggest "
-"you to buy a [Raspberry Pi](https://www.raspberrypi.org/){: target=\"_blank"
-"\" rel=\"noopener noreferrer\" } which is an inexpensive and small device "
-"that performs very well with Jamulus. Android support is just a proof of "
-"concept."
+"you to buy a [Raspberry Pi](https://www.raspberrypi.org/){: "
+"target=\"_blank\" rel=\"noopener noreferrer\" } which is an inexpensive and "
+"small device that performs very well with Jamulus. Android support is just a "
+"proof of concept."
 msgstr ""
-"Bien que vous **pouvez** installer Jamulus sur des appareils Android (et "
+"Bien que vous **puissiez** installer Jamulus sur des appareils Android (et "
 "entendre du son), nous vous recommandons fortement de **ne** pas le faire. "
 "La qualité du son - surtout en WiFi - est généralement mauvaise et la "
 "latence est élevée. Si vous ne possédez pas de PC, nous vous suggérons "
-"d'acheter un [Raspberry Pi](https://www.raspberrypi.org/){ : target=\"_blank"
-"\" rel=\"noopener noreferrer\" } qui est un petit appareil bon marché qui "
-"fonctionne très bien avec Jamulus. Le support Android n'est qu'une preuve de "
-"concept."
+"d'acheter un [Raspberry Pi](https://www.raspberrypi.org/){ : "
+"target=\"_blank\" rel=\"noopener noreferrer\" } qui est un petit appareil "
+"bon marché qui fonctionne très bien avec Jamulus. Le support Android n'est "
+"qu'une preuve de concept."
 
 #. type: Plain text
 #: wiki/en/Installation-for-Android.md:20
@@ -109,18 +112,18 @@ msgstr ""
 #. type: Plain text
 #: wiki/en/Installation-for-Android.md:25
 msgid ""
-"[Download and install Jamulus]({{ site.download_root_link }}{{ site."
-"download_file_names.android }}){: .button}"
+"[Download and install Jamulus]({{ site.download_root_link }}{{ "
+"site.download_file_names.android }}){: .button}"
 msgstr ""
-"[Télécharger et installer Jamulus]({{ site.download_root_link }}{ site."
-"download_file_names.android }}){ : .button}"
+"[Télécharger et installer Jamulus]({{ site.download_root_link }}{ "
+"site.download_file_names.android }}){ : .button}"
 
 #. type: Plain text
 #: wiki/en/Installation-for-Android.md:26
 msgid "You should now be able to run Jamulus on your Android device"
 msgstr ""
 "Vous devriez maintenant être en mesure d'exécuter Jamulus sur votre appareil "
-"Android."
+"Android"
 
 #. type: Plain text
 #: wiki/en/Installation-for-Android.md:28
@@ -131,8 +134,8 @@ msgstr "## Commentaires et développement"
 #: wiki/en/Installation-for-Android.md:30
 msgid ""
 "We are very happy to get feedback from Android users and developers. Just "
-"head over to the [Jamulus GitHub repo](https://github.com/jamulussoftware/"
-"jamulus/)."
+"head over to the [Jamulus GitHub "
+"repo](https://github.com/jamulussoftware/jamulus/)."
 msgstr ""
 "Nous sommes très heureux de recevoir les commentaires des utilisateurs et "
 "des développeurs Android. Il vous suffit de vous rendre sur le [repo GitHub "

--- a/wiki/fr/Installation-for-Android.md
+++ b/wiki/fr/Installation-for-Android.md
@@ -14,7 +14,7 @@ Assurez-vous d'avoir déjà lu la page [Getting Started](Getting-Started).
 
 ## Choses à noter à propos d'Android
 
-Bien que vous **pouvez** installer Jamulus sur des appareils Android (et entendre du son), nous vous recommandons fortement de **ne** pas le faire. La qualité du son - surtout en WiFi - est généralement mauvaise et la latence est élevée. Si vous ne possédez pas de PC, nous vous suggérons d'acheter un [Raspberry Pi](https://www.raspberrypi.org/){ : target="_blank" rel="noopener noreferrer" } qui est un petit appareil bon marché qui fonctionne très bien avec Jamulus. Le support Android n'est qu'une preuve de concept.
+Bien que vous **puissiez** installer Jamulus sur des appareils Android (et entendre du son), nous vous recommandons fortement de **ne** pas le faire. La qualité du son - surtout en WiFi - est généralement mauvaise et la latence est élevée. Si vous ne possédez pas de PC, nous vous suggérons d'acheter un [Raspberry Pi](https://www.raspberrypi.org/){ : target="_blank" rel="noopener noreferrer" } qui est un petit appareil bon marché qui fonctionne très bien avec Jamulus. Le support Android n'est qu'une preuve de concept.
 
 ## Installer le PoC Android
 
@@ -22,7 +22,7 @@ Si vous voulez essayer Jamulus sur Android :
 
 1. Autorisez l'installation d'applications provenant de sources inconnues (regardez dans Paramètres>Sécurité. Remarque : la manière exacte de le faire dépend de votre appareil et de la version de votre système d'exploitation.)
 1. [Télécharger et installer Jamulus]({{ site.download_root_link }}{ site.download_file_names.android }}){ : .button}
-1. Vous devriez maintenant être en mesure d'exécuter Jamulus sur votre appareil Android.
+1. Vous devriez maintenant être en mesure d'exécuter Jamulus sur votre appareil Android
 
 ## Commentaires et développement
 


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

In `Installation-for-Android.po` and `Installation-for-Android.md` fixing typo "pouvez -> puissiez" French grammar rule.

Fixing #1890
