### PR TITLE
Add translation stats script

### DIFF
--- a/po4a-create-all-targets.sh
+++ b/po4a-create-all-targets.sh
@@ -83,7 +83,7 @@ use_po_module () {
 			--format asciidoc \
 			--master "$file" \
 			--master-charset "UTF-8" \
-			--po "$PO_DIR/$lang/$basename.po" \
+			--po "$PO_DIR/$lang/${basename}.po" \
 			--localized "$localized_file" --localized-charset "UTF-8" \
 			--keep "$THRESHOLD"
 
@@ -93,6 +93,7 @@ use_po_module () {
 		if [ -f $trans_file ] ; then
 		    echo "$basename".md translated into "$lang"
 		fi
+		
 	done <   <(find -L "$SRC_DIR" -name "*.md"  -print0)
 }
 
@@ -105,4 +106,7 @@ while IFS= read -r -d '' dir ; do
 	echo "$lang"
 	use_po_module "$lang"   
 done <   <(find "$PO_DIR" -mindepth 1 -maxdepth 1 -type d -print0)
+
+# Produce a file with translation status of all .po files
+source ./po4a-stats.sh
 

--- a/po4a-stats.sh
+++ b/po4a-stats.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# You need gettext
+# You may set the following variables:
+# SRC_DIR folder for original source English .md files
+# PO_DIR directory where .po files are stored
+
+# Folder where source English .md files are
+#SRC_DIR="./wiki/en"
+
+# Directory where the po file folders are
+#if [ -z "$PO_DIR" ] ; then
+#	PO_DIR="./translator-files/po"
+#fi
+
+# Remove stats file before creating new one
+rm -f "translator-files/statistics"
+
+produce_stats () { 
+# Determine file names
+	while IFS= read -r -d '' file ; do
+		basename="$(basename -s .md "$file")"
+		
+		# Stats printed to translator-files/statistics.txt
+		echo "$lang"/"$basename".po >> translator-files/statistics
+		msgfmt --statistics "$PO_DIR/$lang/$basename".po &>> translator-files/statistics
+		echo '' >> translator-files/statistics
+		
+	done <   <(find -L "$SRC_DIR" -name "*.md"  -print0)
+	echo '' >> translator-files/statistics
+}
+
+# Run produce_stats on each language folder
+while IFS= read -r -d '' dir ; do
+	lang=$(basename -s .md "$dir")
+	echo "$lang": >> translator-files/statistics
+	produce_stats "$lang"
+done <   <(find "$PO_DIR" -mindepth 1 -maxdepth 1 -type d -print0)
+
+echo Statistics file created
+

--- a/po4a-stats.sh
+++ b/po4a-stats.sh
@@ -1,16 +1,5 @@
 #!/bin/bash
 # You need gettext
-# You may set the following variables:
-# SRC_DIR folder for original source English .md files
-# PO_DIR directory where .po files are stored
-
-# Folder where source English .md files are
-#SRC_DIR="./wiki/en"
-
-# Directory where the po file folders are
-#if [ -z "$PO_DIR" ] ; then
-#	PO_DIR="./translator-files/po"
-#fi
 
 # Remove stats file before creating new one
 rm -f "translator-files/statistics"

--- a/po4a-stats.sh
+++ b/po4a-stats.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# You need gettext
 
 # Remove stats file before creating new one
 rm -f "translator-files/statistics"
@@ -9,7 +8,7 @@ produce_stats () {
 	while IFS= read -r -d '' file ; do
 		basename="$(basename -s .md "$file")"
 		
-		# Stats printed to translator-files/statistics.txt
+		# Stats printed to translator-files/statistics
 		echo "$lang"/"$basename".po >> translator-files/statistics
 		msgfmt --statistics "$PO_DIR/$lang/$basename".po &>> translator-files/statistics
 		echo '' >> translator-files/statistics

--- a/po4a-update-templates.sh
+++ b/po4a-update-templates.sh
@@ -46,7 +46,7 @@ fi
 
 while IFS= read -r -d '' file ; do
     # Determine target file/folder names
-    basename=$(basename -s .md "$file")
+    basename="$(basename -s .md "$file")"
 
     for lang in $(ls "$PO_DIR") ; do
 
@@ -83,3 +83,6 @@ for lang in $(ls "$PO_DIR") ; do
 	    rm "$PO_DIR/$lang/"*.po~
     fi
 done
+
+# Produce a file with translation status of all .po files
+source ./po4a-stats.sh

--- a/translator-files/statistics
+++ b/translator-files/statistics
@@ -1,0 +1,475 @@
+pt:
+pt/Compiling.po
+3 translated messages, 2 untranslated messages.
+
+pt/Installation-for-Android.po
+8 translated messages, 12 untranslated messages.
+
+pt/index.po
+1 translated message, 4 untranslated messages.
+
+pt/Choosing-a-Server-Type.po
+2 translated messages, 27 untranslated messages.
+
+pt/Running-a-Server.po
+3 translated messages, 29 untranslated messages.
+
+pt/Tips-Tricks-More.po
+2 translated messages, 53 untranslated messages.
+
+pt/Server-Troubleshooting.po
+2 translated messages, 26 untranslated messages.
+
+pt/Multiple-Audio-Interfaces.po
+0 translated messages, 5 untranslated messages.
+
+pt/Network-Requirements.po
+2 translated messages, 17 untranslated messages.
+
+pt/Privacy-Statement.po
+2 translated messages, 18 untranslated messages.
+
+pt/Running-a-Private-Server.po
+3 translated messages, 26 untranslated messages.
+
+pt/Linux-Install-Script.po
+0 translated messages, 5 untranslated messages.
+
+pt/Demos.po
+2 translated messages, 11 untranslated messages.
+
+pt/Hardware-Setup.po
+4 translated messages, 40 untranslated messages.
+
+pt/Installation-for-Linux.po
+29 translated messages.
+
+pt/Server-Rpi.po
+3 translated messages, 2 untranslated messages.
+
+pt/Directory-Servers.po
+2 translated messages, 9 untranslated messages.
+
+pt/FAQ.po
+2 translated messages, 24 untranslated messages.
+
+pt/Server-Win-Mac.po
+4 translated messages, 30 untranslated messages.
+
+pt/Installation-for-Windows.po
+47 translated messages, 1 fuzzy translation.
+
+pt/Central-Servers.po
+3 translated messages, 2 untranslated messages.
+
+pt/Installation-for-Macintosh.po
+23 translated messages, 1 fuzzy translation, 1 untranslated message.
+
+pt/Getting-Started.po
+37 translated messages, 1 untranslated message.
+
+pt/Sound-Devices.po
+3 translated messages, 2 untranslated messages.
+
+pt/Software-Manual.po
+2 translated messages, 106 untranslated messages.
+
+pt/Server-Linux.po
+3 translated messages, 38 untranslated messages.
+
+pt/Contribution.po
+2 translated messages, 8 untranslated messages.
+
+pt/Software-Synth.po
+3 translated messages, 2 untranslated messages.
+
+pt/Client-Troubleshooting.po
+3 translated messages, 45 untranslated messages.
+
+pt/Onboarding.po
+3 translated messages, 2 untranslated messages.
+
+pt/Command-Line-Options.po
+3 translated messages, 16 untranslated messages.
+
+
+fr:
+fr/Compiling.po
+0 translated messages, 5 untranslated messages.
+
+fr/Installation-for-Android.po
+20 translated messages.
+
+fr/index.po
+5 translated messages.
+
+fr/Choosing-a-Server-Type.po
+29 translated messages.
+
+fr/Running-a-Server.po
+32 translated messages.
+
+fr/Tips-Tricks-More.po
+55 translated messages.
+
+fr/Server-Troubleshooting.po
+28 translated messages.
+
+fr/Multiple-Audio-Interfaces.po
+0 translated messages, 5 untranslated messages.
+
+fr/Network-Requirements.po
+19 translated messages.
+
+fr/Privacy-Statement.po
+20 translated messages.
+
+fr/Running-a-Private-Server.po
+29 translated messages.
+
+fr/Linux-Install-Script.po
+0 translated messages, 5 untranslated messages.
+
+fr/Demos.po
+13 translated messages.
+
+fr/Hardware-Setup.po
+44 translated messages.
+
+fr/Installation-for-Linux.po
+29 translated messages.
+
+fr/Server-Rpi.po
+0 translated messages, 5 untranslated messages.
+
+fr/Directory-Servers.po
+11 translated messages.
+
+fr/FAQ.po
+26 translated messages.
+
+fr/Server-Win-Mac.po
+34 translated messages.
+
+fr/Installation-for-Windows.po
+47 translated messages, 1 fuzzy translation.
+
+fr/Central-Servers.po
+0 translated messages, 5 untranslated messages.
+
+fr/Installation-for-Macintosh.po
+24 translated messages, 1 fuzzy translation.
+
+fr/Getting-Started.po
+38 translated messages.
+
+fr/Sound-Devices.po
+0 translated messages, 5 untranslated messages.
+
+fr/Software-Manual.po
+108 translated messages.
+
+fr/Server-Linux.po
+41 translated messages.
+
+fr/Contribution.po
+10 translated messages.
+
+fr/Software-Synth.po
+0 translated messages, 5 untranslated messages.
+
+fr/Client-Troubleshooting.po
+48 translated messages.
+
+fr/Onboarding.po
+0 translated messages, 5 untranslated messages.
+
+fr/Command-Line-Options.po
+19 translated messages.
+
+
+it:
+it/Compiling.po
+1 translated message, 4 untranslated messages.
+
+it/Installation-for-Android.po
+7 translated messages, 13 untranslated messages.
+
+it/index.po
+1 translated message, 4 untranslated messages.
+
+it/Choosing-a-Server-Type.po
+2 translated messages, 27 untranslated messages.
+
+it/Running-a-Server.po
+2 translated messages, 30 untranslated messages.
+
+it/Tips-Tricks-More.po
+2 translated messages, 53 untranslated messages.
+
+it/Server-Troubleshooting.po
+2 translated messages, 26 untranslated messages.
+
+it/Multiple-Audio-Interfaces.po
+1 translated message, 4 untranslated messages.
+
+it/Network-Requirements.po
+2 translated messages, 17 untranslated messages.
+
+it/Privacy-Statement.po
+2 translated messages, 18 untranslated messages.
+
+it/Running-a-Private-Server.po
+2 translated messages, 27 untranslated messages.
+
+it/Linux-Install-Script.po
+1 translated message, 4 untranslated messages.
+
+it/Demos.po
+2 translated messages, 11 untranslated messages.
+
+it/Hardware-Setup.po
+3 translated messages, 41 untranslated messages.
+
+it/Installation-for-Linux.po
+4 translated messages, 25 untranslated messages.
+
+it/Server-Rpi.po
+0 translated messages, 5 untranslated messages.
+
+it/Directory-Servers.po
+2 translated messages, 9 untranslated messages.
+
+it/FAQ.po
+2 translated messages, 24 untranslated messages.
+
+it/Server-Win-Mac.po
+3 translated messages, 31 untranslated messages.
+
+it/Installation-for-Windows.po
+6 translated messages, 42 untranslated messages.
+
+it/Central-Servers.po
+1 translated message, 4 untranslated messages.
+
+it/Installation-for-Macintosh.po
+10 translated messages, 1 fuzzy translation, 14 untranslated messages.
+
+it/Getting-Started.po
+1 translated message, 37 untranslated messages.
+
+it/Sound-Devices.po
+1 translated message, 4 untranslated messages.
+
+it/Software-Manual.po
+2 translated messages, 106 untranslated messages.
+
+it/Server-Linux.po
+2 translated messages, 39 untranslated messages.
+
+it/Contribution.po
+2 translated messages, 8 untranslated messages.
+
+it/Software-Synth.po
+1 translated message, 4 untranslated messages.
+
+it/Client-Troubleshooting.po
+3 translated messages, 45 untranslated messages.
+
+it/Onboarding.po
+1 translated message, 4 untranslated messages.
+
+it/Command-Line-Options.po
+3 translated messages, 16 untranslated messages.
+
+
+es:
+es/Compiling.po
+0 translated messages, 5 untranslated messages.
+
+es/Installation-for-Android.po
+20 translated messages.
+
+es/index.po
+5 translated messages.
+
+es/Choosing-a-Server-Type.po
+29 translated messages.
+
+es/Running-a-Server.po
+32 translated messages.
+
+es/Tips-Tricks-More.po
+55 translated messages.
+
+es/Server-Troubleshooting.po
+28 translated messages.
+
+es/Multiple-Audio-Interfaces.po
+0 translated messages, 5 untranslated messages.
+
+es/Network-Requirements.po
+19 translated messages.
+
+es/Privacy-Statement.po
+20 translated messages.
+
+es/Running-a-Private-Server.po
+29 translated messages.
+
+es/Linux-Install-Script.po
+0 translated messages, 5 untranslated messages.
+
+es/Demos.po
+13 translated messages.
+
+es/Hardware-Setup.po
+44 translated messages.
+
+es/Installation-for-Linux.po
+29 translated messages.
+
+es/Server-Rpi.po
+0 translated messages, 5 untranslated messages.
+
+es/Directory-Servers.po
+11 translated messages.
+
+es/FAQ.po
+26 translated messages.
+
+es/Server-Win-Mac.po
+34 translated messages.
+
+es/Installation-for-Windows.po
+47 translated messages, 1 fuzzy translation.
+
+es/Central-Servers.po
+0 translated messages, 5 untranslated messages.
+
+es/Installation-for-Macintosh.po
+24 translated messages, 1 fuzzy translation.
+
+es/Getting-Started.po
+38 translated messages.
+
+es/Sound-Devices.po
+0 translated messages, 5 untranslated messages.
+
+es/Software-Manual.po
+108 translated messages.
+
+es/Server-Linux.po
+41 translated messages.
+
+es/Contribution.po
+10 translated messages.
+
+es/Software-Synth.po
+0 translated messages, 5 untranslated messages.
+
+es/Client-Troubleshooting.po
+48 translated messages.
+
+es/Onboarding.po
+0 translated messages, 5 untranslated messages.
+
+es/Command-Line-Options.po
+19 translated messages.
+
+
+de:
+de/Compiling.po
+1 translated message, 4 untranslated messages.
+
+de/Installation-for-Android.po
+20 translated messages.
+
+de/index.po
+1 translated message, 4 untranslated messages.
+
+de/Choosing-a-Server-Type.po
+2 translated messages, 27 untranslated messages.
+
+de/Running-a-Server.po
+3 translated messages, 29 untranslated messages.
+
+de/Tips-Tricks-More.po
+2 translated messages, 53 untranslated messages.
+
+de/Server-Troubleshooting.po
+2 translated messages, 26 untranslated messages.
+
+de/Multiple-Audio-Interfaces.po
+1 translated message, 4 untranslated messages.
+
+de/Network-Requirements.po
+2 translated messages, 17 untranslated messages.
+
+de/Privacy-Statement.po
+2 translated messages, 18 untranslated messages.
+
+de/Running-a-Private-Server.po
+2 translated messages, 27 untranslated messages.
+
+de/Linux-Install-Script.po
+1 translated message, 4 untranslated messages.
+
+de/Demos.po
+2 translated messages, 11 untranslated messages.
+
+de/Hardware-Setup.po
+4 translated messages, 40 untranslated messages.
+
+de/Installation-for-Linux.po
+29 translated messages.
+
+de/Server-Rpi.po
+1 translated message, 4 untranslated messages.
+
+de/Directory-Servers.po
+2 translated messages, 9 untranslated messages.
+
+de/FAQ.po
+2 translated messages, 24 untranslated messages.
+
+de/Server-Win-Mac.po
+3 translated messages, 31 untranslated messages.
+
+de/Installation-for-Windows.po
+47 translated messages, 1 fuzzy translation.
+
+de/Central-Servers.po
+1 translated message, 4 untranslated messages.
+
+de/Installation-for-Macintosh.po
+24 translated messages, 1 fuzzy translation.
+
+de/Getting-Started.po
+38 translated messages.
+
+de/Sound-Devices.po
+1 translated message, 4 untranslated messages.
+
+de/Software-Manual.po
+2 translated messages, 106 untranslated messages.
+
+de/Server-Linux.po
+2 translated messages, 39 untranslated messages.
+
+de/Contribution.po
+2 translated messages, 8 untranslated messages.
+
+de/Software-Synth.po
+1 translated message, 4 untranslated messages.
+
+de/Client-Troubleshooting.po
+3 translated messages, 45 untranslated messages.
+
+de/Onboarding.po
+2 translated messages, 3 untranslated messages.
+
+de/Command-Line-Options.po
+3 translated messages, 16 untranslated messages.
+
+


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [* ] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

Added a script that gets called from either po4a-update-templates.sh or po4a-create-all-targets.sh. It produces a 'statistics' text file in translator-files/ showing the updated translation status of all .po files for each language.
