### PR TITLE
Wrapping and timestamp fixes, updated READMEs

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,6 +4,8 @@ on:
     branches: [ next-release, release ]
   push:
     branches: [ next-release ]
+    paths:
+      - 'wiki/en/*.md'
 jobs:
   jekyll_site_ci:
     permissions:
@@ -11,6 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+# Paths changes filter. Detects if there's been a change to any files defined in the filter:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            templates:
+              - 'wiki/en/*.md'
 
 # Retrieve po4a installation cache or create it if not found:
       - name: Cache po4a dependencies
@@ -25,15 +36,6 @@ jobs:
 
 # If CACHE_HIT: true, retrieve the cache. If not, install po4a and its dependencies and copy them all to a folder (~/po4a/) to be cached:
         run: ./_po4a-tools/po4a-cache.sh
-
-# Paths changes filter. Detects if there's been a change to any files defined in the filter:
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            templates:
-              - 'wiki/en/*.md'
 
 # If there have been changes to English .md files in /wiki, run po4a-update-templates:
       - name: Update templates

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -52,16 +52,19 @@ jobs:
       - name: Create translated .md docs and stats
         run: ./_po4a-tools/po4a-create-all-targets.sh
 
-# Build, zip and upload site
+# Build, zip and upload site only when triggered by PR to avoid duplicating checks and uploads:
       - name: Build the site in the jekyll/builder container
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker run \
           -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
           jekyll/builder:latest /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll build --future"
       - name: Zip Website
+        if: ${{ github.event_name == 'pull_request' }}
         run: zip -r ${{ github.workspace }}/website.zip _site/*
       - uses: actions/upload-artifact@v2
         name: Upload Website
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           name: Website
           path: ${{ github.workspace }}/website.zip

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -20,11 +20,11 @@ jobs:
         with:
           base: ${{ github.ref }}
           filters: |
-            templates:
+            src_files_changed:
               - 'wiki/en/*.md'
 
 # Retrieve po4a installation cache or create it if not found:
-      - name: Cache po4a dependencies
+      - name: Check for po4a cache
         uses: actions/cache@v1.0.3
         id: cache-po4a
         with:
@@ -38,17 +38,17 @@ jobs:
         run: ./_po4a-tools/po4a-cache.sh
 
 # If there have been changes to English .md files in /wiki, run po4a-update-templates:
-      - name: Update templates
-        if: ${{ steps.filter.outputs.templates == 'true' }}
+      - name: Update .po files
+        if: ${{ steps.filter.outputs.src_files_changed == 'true' }}
         run: ./_po4a-tools/po4a-update-templates.sh
 
 # This step only runs if a PR is merged:
-      - name: Push changes to repo if action triggered on:push and templates need updating
-        if: ${{ github.event_name == 'push' && steps.filter.outputs.templates == 'true' }}
+      - name: Push changes to repo if action triggered on:push and .po files need updating
+        if: ${{ github.event_name == 'push' && steps.filter.outputs.src_files_changed == 'true' }}
         uses: EndBug/add-and-commit@v7
         with:
           default_author: github_actions
-          message: 'AUTO: Update templates'
+          message: 'AUTO: Updated .po files'
 
 # Create translated .md files. Never pushed to the repo.
       - name: Create translated .md docs and stats

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
 # Retrieve po4a installation cache or create it if not found:
-      - name: Cache po4a dependencies
+      - name: Check for po4a cache
         uses: actions/cache@v1.0.3
         id: cache-po4a
         with:
@@ -25,25 +25,25 @@ jobs:
 # If CACHE_HIT: true, retrieve the cache. If not, install po4a and its dependencies and copy them all to a folder (~/po4a/) to be cached:
         run: ./_po4a-tools/po4a-cache.sh
 
-# Paths changes filter. If there's been a change to any files defined in the filter, the step (update templates) runs:
+# Paths changes filter. If there's been a change to any files defined in the filter, the step (update .po files) runs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
           base: ${{ github.ref }}
           filters: |
-            templates:
+            src_files_changed:
               - 'wiki/en/*.md'
-      - name: Update templates
-        if: steps.filter.outputs.templates == 'true'
+      - name: Update .po files
+        if: steps.filter.outputs.src_files_changed == 'true'
         run: ./_po4a-tools/po4a-update-templates.sh
 
 # This step only runs if a PR is merged:
-      - name: Push changes to repo if action triggered on:push and templates need updating
-        if: ${{ steps.filter.outputs.templates == 'true' }}
+      - name: Push changes to repo if action triggered on:push and .po files need updating
+        if: ${{ steps.filter.outputs.src_files_changed == 'true' }}
         uses: EndBug/add-and-commit@v7
         with:
           default_author: github_actions
-          message: 'AUTO: Update templates'
+          message: 'AUTO: Update .po files'
 
 # Create translated .md files. Never pushed to the repo.
       - name: Create translated .md docs and stats

--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -38,19 +38,22 @@ fi
 
 # Check if po4a is installed
 if ! [ -x "$(command -v po4a)" ] ; then
-	echo Error: please install po4a. >&2
+	echo Error: Please install po4a. v0.63 or higher is required >&2
 	exit 1
 fi
 
 # Check if the right version is installed
-if ! [[ $(po4a --version | grep po4a | awk '{print $3}') > 0.63 ]] ; then
-	echo Error: po4a version 0.63 or higher is required. >&2
+PO4A_VER=$(po4a --version | grep po4a | awk '{print $3}')
+
+if [[ $PO4A_VER < 0.63 ]] ; then
+    echo Error: po4a v"$PO4A_VER" is installed >&2
+	echo po4a v0.63 or higher is required. >&2
 	exit 1
 fi
 
 # Check if source document folder exists in the right place
 if ! [ -d "$SRC_DIR" ] ; then
-	echo Error: please run this script from the root folder. >&2
+	echo Error: Please make sure the source English file directory exists. >&2
 	exit 1
 fi
 

--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -46,7 +46,7 @@ fi
 PO4A_VER=$(po4a --version | grep po4a | awk '{print $3}')
 
 if [[ $PO4A_VER < 0.63 ]] ; then
-    echo Error: po4a v"$PO4A_VER" is installed >&2
+	echo Error: po4a v"$PO4A_VER" is installed >&2
 	echo po4a v0.63 or higher is required. >&2
 	exit 1
 fi

--- a/_po4a-tools/po4a-update-templates.sh
+++ b/_po4a-tools/po4a-update-templates.sh
@@ -36,7 +36,7 @@ fi
 PO4A_VER=$(po4a --version | grep po4a | awk '{print $3}')
 
 if [[ $PO4A_VER < 0.63 ]] ; then
-    echo Error: po4a v"$PO4A_VER" is installed >&2
+	echo Error: po4a v"$PO4A_VER" is installed >&2
 	echo po4a v0.63 or higher is required. >&2
 	exit 1
 fi

--- a/_po4a-tools/po4a-update-templates.sh
+++ b/_po4a-tools/po4a-update-templates.sh
@@ -28,19 +28,22 @@ fi
 
 # Check if po4a is installed
 if ! [ -x "$(command -v po4a)" ] ; then
-	echo Error: please install po4a. >&2
+	echo Error: Please install po4a. v0.63 or higher is required >&2
 	exit 1
 fi
 
 # Check if the right version is installed
-if ! [[ $(po4a --version | grep po4a | awk '{print $3}') > 0.63 ]] ; then
-	echo Error: po4a version 0.63 or higher is required. >&2
+PO4A_VER=$(po4a --version | grep po4a | awk '{print $3}')
+
+if [[ $PO4A_VER < 0.63 ]] ; then
+    echo Error: po4a v"$PO4A_VER" is installed >&2
+	echo po4a v0.63 or higher is required. >&2
 	exit 1
 fi
 
 # Check if source document folder exists in the right place
 if ! [ -d "$SRC_DIR" ] ; then
-	echo Error: please run this script from the root folder. >&2
+	echo Error: Please make sure the source English file directory exists. >&2
 	exit 1
 fi
 
@@ -64,15 +67,17 @@ while IFS= read -r -d '' file ; do
             echo creating "$po_file"
         fi
 
+        # Update/create .po files
         if ! po4a-updatepo \
             --format asciidoc \
             --master "$file" \
             --master-charset "UTF-8" \
-            --wrap-po no \
+            --msgmerge-opt  --no-wrap \
             --po "$po_file" ; then
         echo ''
         echo Error updating "$lang" PO file for: "$basename.md"
         fi
+
     done
 done <   <(find -L "$SRC_DIR" -name "*.md" -print0)
 
@@ -87,4 +92,7 @@ for lang in $(ls "$PO_DIR") ; do
     if ls $temp_file 1> /dev/null 2>&1 ; then
 	    rm "$PO_DIR/$lang/"*.po~
     fi
+
+    # Delete line in file header that pollutes commits
+    sed -i '/^"POT-Creation-Date:/d' $PO_DIR/$lang/*.po
 done

--- a/_translator-files/README.md
+++ b/_translator-files/README.md
@@ -1,6 +1,6 @@
 # Website docs translation:
 
--   Navigate to `_translator-files/po/YOUR-LANGUAGE/`. Translate the content of the .po files in your editor of choice (QtLinguist, Lokalize, OmegaT...).
+-   Navigate to `_translator-files/po/YOUR-LANGUAGE/`. Translate the content of the .po files in your editor of choice (Poedit, OmegaT...).
 -   Set the lang: parameter to your language code at the beginning of the file (it, fr, de, etc.) and make sure the permalink: parameter (e.g. /wiki/Client-Troubleshooting) stays the same.
 -   Submit a Pull Request with the translated .po files. **DO NOT** edit any .md files in the /wiki/ folder.
 
@@ -34,11 +34,15 @@ Please also take into account the following:
 
 #### Suggested po file editors:
 
-- OmegaT (cross-platform): the most complete and advanced, but also somewhat more complex. A guide is included in this folder.
-- QtLinguist (cross-platform): if you've done app translations you should feel comfortable with this. However, you have to open files one by one and until you do, you can't know the state of the translation.
-- Lokalize (Linux): GUI similar to QtLinguist but more complete.
-    - This application can give you an overview of the translation progress of all files. Click on `Project > Create software translation project`. A window will open asking where to store the `index` file - choose anywhere you want. Now another window will open. In "Root folder" point it to the directory where all the .po files for your language are. Click on "Apply" and "OK". Now you will be shown an overview of the state of all the translations. Double-click on one to go to that file. If you are comfortable with this editor and use Linux, it's a very recommendable option if you don't want to get into the complexities of OmegaT.
-- Virtaal (cross-platform)
-- Gtranslator (Linux)
+- [OmegaT](https://omegat.org/) (cross-platform): the most complete and advanced, but also somewhat more complex. A guide is included in this folder.
+- [Poedit](https://github.com/vslavik/poedit) (cross-platform): Intuitive to use, though a couple of things need to be configured before starting to translate with it for the first time:
+    - Go to Edit > Preferences
+    - In the "General" tab, uncheck "Automatically compile MO file when saving"
+    - In the "Advanced" tab, uncheck "Wrap at:". Otherwise it will wrap all the strings at a given column and we don't want that, as changes in text wrapping cause a flood of edits to be added to pull requests. Each editor seems to have its own criterion for text wrapping, so it has been disabled by the po4a scripts running on the repository.
+    For an overall view of all files and their status, go to File > Catalogs Manager. Click on New > Browse and  enter the path to your .po files. Click on "OK". You should now see a list of all the .po files and their current translation status. Double-click on any one of them to open it in a new window.
 
-For short edits or single file translations, QtLinguist, Lokalize or a similar editor might be simpler to use. For working through all the files, OmegaT will be much more suitable (see guide).
+- Qt Linguist or Lokalize can also be used, but they are strongly discouraged as they do not offer the option to disable text wrapping (Lokalize does, but it still messes it up).
+
+If you use a different editor to those listed, please make sure you can disable text wrapping (but still preserve the wrapping of the metadata at the top - this is important), and tell us about it so we can add it to the list.
+
+For short edits or single file translations, Poedit or a similar editor might be simpler to use. For working through all the files, OmegaT will be more suitable (see guide).

--- a/_translator-files/translate-with-omegat.md
+++ b/_translator-files/translate-with-omegat.md
@@ -1,6 +1,6 @@
 # Guide for translating .po files using OmegaT
 
-If you're just going to edit a single .po file, or translate a short one, it may be easier to simply use an editor like QtLinguist, Virtaal, Lokalize, Gtranslator, etc. which allow you to edit the .po file directly, in-place, without the need to copy/paste it anywhere, and without really needing to learn how to use these tools - they are very intuitive to use. However, if you intend to work through all the website documents, these applications have cluttered GUIs that will make translating a large volume of text quite uncomfortable. In addition, they can't give you (except for Lokalize) a complete overview of all the files as a single project, meaning that if you want to check the state of translations, you have to open them one by one, which is time-consuming and inefficient. 
+If you're just going to edit a single .po file, or translate a short one, it may be easier to simply use an editor like Poedit, which allows you to edit the .po file directly, in-place, without the need to copy/paste it anywhere, and without really needing to learn how to use this tool - it is very intuitive to use. However, if you intend to work through all the website documents, this application has a small, restricted text editor window that will make translating a large volume of text quite uncomfortable.
 
 OmegaT lets you group all files into a single project and can give you information on all of them in a single place. Its interface is also much more convenient to work with. However, as a more advanced tool, it requires some setting up. Once the initial setup has been done though, any future edits/translations are just a matter of copy/pasting a folder and firing up OmegaT.
 
@@ -23,4 +23,4 @@ OmegaT lets you group all files into a single project and can give you informati
 1. When you have finished your translations, go to `Project > Create Translated Documents`. Your translated files will be created in `path/to/_translator-files/po/`, replacing the ones there.
 
 
- From now on, when there are new files to translate or they have been updated on GitHub, it's simply a matter of copy/pasting the latest version of the .po file folder for your language to the "source" folder, as in point 3 above.
+ From now on, when there are new files to translate or they have been updated on GitHub, it's simply a matter of copy/pasting the latest version of the .po file folder for your language to the "source" folder, as in point 3 above, replacing it.

--- a/contribute/en/po4a-Setup-Explained.md
+++ b/contribute/en/po4a-Setup-Explained.md
@@ -15,7 +15,7 @@ First though, a brief overview.
 
 In broad terms, there are three types of activity that take place on the website repository:
 
-- Editing/adding/updating translatable documentation in English, the source language that all translations are based on. Translators now need to know _where_ these changes have taken place, preferably without having to actually scan the documents in English or trawling through PRs.
+- Editing/adding/updating translatable documentation in English, the source language that all translations are based on. Translators now need to know _where_ these changes have taken place, preferably without having to actually scan the documents in English or trawl through PRs.
 - Translating these documents into each respective language. As translations now take place in special .po files, these need to be converted back into .md format for the website.
 - Editing other content in the repository that is not necessarily the documentation itself (scripts, config files, images, etc.). This activity is largely unaffected by the new setup.
 

--- a/contribute/en/po4a-Setup-Explained.md
+++ b/contribute/en/po4a-Setup-Explained.md
@@ -96,7 +96,7 @@ This is the more complex script. A distinction between 'pull request' and 'push'
 
     5- Translated .md files are created with `po4a-create-all-targets.sh`.
 
-    6- Site is built, zipped and uploaded as an artifact. This is so the contributor can download and view the site locally, to check translations as they would appear on the website or the overall appearance of the website if other content has been edited (config files, images, etc.) before the PR is merged. Only happens if the trigger was a PR.
+    6- Site is built, zipped and uploaded as an artifact. This is so the contributor can download, unzip twice and view the site locally (e.g. with a [local webserver](https://pythonbasics.org/webserver/)), to check translations as they would appear on the website or the overall appearance of the website if other content has been edited (config files, images, etc.) before the PR is merged. Only happens if the trigger was a PR.
 
 - **Push events**. Only applicable to 'next-release':
 

--- a/contribute/en/po4a-Setup-Explained.md
+++ b/contribute/en/po4a-Setup-Explained.md
@@ -17,7 +17,7 @@ In broad terms, there are three types of activity that take place on the website
 
 - Editing/adding/updating translatable documentation in English, the source language that all translations are based on. Translators need to know _where_ these changes have taken place, preferably without having to actually scan the documents in English or trawl through PRs.
 - Translating these documents into each respective language. As translations take place in special .po files, these need to be converted back into .md format for the website.
-- Editing other content in the repository that is not necessarily the documentation itself (scripts, config files, images, etc.). This activity is largely unaffected by the new setup.
+- Editing other content in the repository that is not necessarily the documentation itself (scripts, config files, images, etc.).
 
 So here the focus is on the first two points, as they are what the po4a setup seeks to address, namely:
 

--- a/contribute/en/po4a-Setup-Explained.md
+++ b/contribute/en/po4a-Setup-Explained.md
@@ -1,0 +1,117 @@
+---
+layout: wiki
+title: "po4a Setup Explained"
+lang: "en"
+permalink: "/contribute/po4a-Setup-Explained"
+---
+
+# po4a Setup Explained
+
+This document is a description of the po4a-based processes that are behind the website translation and documentation maintenance workflow. It mainly focuses on the scripts automating these processes, describing the function of each one of them in an attempt to provide an understanding of how they all fit together.
+
+First though, a brief overview.
+
+## Contributor activities
+
+In broad terms, there are three types of activity that take place on the website repository:
+
+- Editing/adding/updating translatable documentation in English, the source language that all translations are based on. Translators now need to know _where_ these changes have taken place, preferably without having to actually scan the documents in English or trawling through PRs.
+- Translating these documents into each respective language. As translations now take place in special .po files, these need to be converted back into .md format for the website.
+- Editing other content in the repository that is not necessarily the documentation itself (scripts, config files, images, etc.). This activity is largely unaffected by the new setup.
+
+So here the focus is on the first two points, as they are what the po4a setup seeks to address, namely:
+
+1 - Whenever a change happens to a document in English (contained in `wiki/en/`), or a new document is added, to automatically provide translators with a version of that document (a .po file) that reflects its current state and is divided into paragraphs (segments) for its translation using an appropriate editor. This removes the need for having to scan documents or PRs for changes to source documents and enables translation via an interface that keeps track of untranslated segments, fuzzy matches, etc. Thus, translators only have to focus on the .po files for their respective languages, which will reflect the current status of the source file and the translation at all times.
+
+2 - When translators submit their translated .po files via a PR and when the PR is merged, these files are automatically processed to generate the target translated files in .md format. Neither maintainers nor contributors should have to worry about processing .po files to obtain the target translated files.
+
+In order to make these automated processes happen, there are a series of scripts that can be divided into two categories: the **po4a scripts**, which perform the processing of the source .md files and .po files; and the **GitHub actions scripts**, which call the appropriate po4a scripts depending on what event they have been triggered by; e.g. a change to a source .md file, a PR with translated .po files, etc.
+
+## The po4a scripts
+
+These are contained in the `_po4a-tools/` folder and there are 4 of them:
+
+**po4a-update-templates.sh**:
+When a source .md file in English is edited, this script will update its .po file counterparts in every language, adding/removing/changing the relevant strings as applicable. If a new .md file has been added, it will create the corresponding new .po file. Similarly, if a new language is added (also automated - more on this later), it will populate the new language folder with all the appropriate .po files. In short, this script will update/create all the relevant .po files in every language folder contained in `_translator-files/po/`.
+
+**po4a-create-all-targets.sh**:
+This script takes all the .po files in `_translator-files/po/*LANG*/` and uses them to generate the target translated .md files ready to be deployed. These target .md files are not stored in the repository, but are created via a GitHub action (which calls this script) just prior to deploying the website or zipping and uploading it (more on this later). This script also triggers the next one before exiting (`po4a-stats.sh`).
+
+**po4a-stats.sh**:
+This creates a file that provides information on the translation status of all .po files, for each language. It shows how many strings have been translated, how many remain to be translated and how many fuzzy matches (partially translated strings) there are in each file. This file is created as `contribute/en/Statistics.md` and like the target .md files, it is not stored in the repository.
+
+**po4a-cache.sh**:
+This simply contains a series of commands that are common to all the GitHub action workflow files and is called when the relevant step is triggered.
+
+## The GitHub Actions scripts
+
+These are contained in `.github/workflows/` and among other things, they automate the execution of the appropriate po4a scripts depending on the event that triggers them.
+
+The website repository operates with two branches - 'release', which is the source for the live website, and 'next-release', which is where changes to the documentation happen in between releases of the Jamulus application. These different functions are relevant when it comes to how the GitHub actions scripts behave, explained as follows:
+
+**main.yml**:
+This script is triggered by 'push' events to the 'release' branch only. This is a summary of what it does:
+
+1- Checks whether po4a and its dependencies have been previously cached. If they have, it retrieves the cache, and if not, it performs the installation and creates the cache so it is available in future - this step is shared by all three GH actions scripts and is what is in the `po4a-cache.sh` script. The po4a installation is necessary to run the po4a scripts later in the workflow. A po4a .deb file is stored in the 'assets' jamulus repository as a recent version is required that is not available from any official repositories.
+
+2- dorny/paths-filter@v2 checks whether the commits being pushed contain any changes to English .md files in `wiki/en/`. If so, `po4a-update-templates.sh` is run to update/add the .po files for all languages.
+
+3- If the previous step is 'true', this means the .po files that have just been updated/added need to be pushed to the repository, which is what this step does. If 'false', this step is skipped as there is nothing new to push.
+
+4- The `po4a-create-all-targets.sh` script is run to create the translated .md files. They are not pushed, but they need to be created to be deployed to the website. The 'Statistics.md' file is also created.
+
+5- The website is built and deployed.
+
+6- A separate job, 'sync-branch', waits for the previous job to finish and then syncs 'release' in its current state to 'next-release'.
+
+**add-lang.yml**:
+This script is for adding a new language. It is triggered when an issue is opened containing a language code in either [xx] or [xx_XX] format in the title (e.g. "Add Portuguese [pt]" or "Add Brazilian Portuguese [pt_BR]") _and then_ the "new language" label is added. Summary:
+
+1- Checks whether the label added is "new language". If it is not, the whole workflow is skipped.
+
+2- Checks the format of the language code in the title and only accepts the format mentioned above. If it doesn't match, an error message is displayed and the script exits.
+
+3- Checks for the po4a cache as above.
+
+4- Creates a new directory in `_translator-files/po/` with the language code taken from the title.
+
+5- Runs `po4a-update-templates.sh` to populate the new folder with its .po files.
+
+6- Creates the target .md files with `po4a-create-all-targets.sh` and the 'Statistics' file.
+
+7- Builds the site but doesn't deploy nor zip/upload it - this and the previous step are just a check to verify that it builds properly.
+
+**jekyll.yml**:
+This is the more complex script. A distinction between 'pull request' and 'push' events will be made to better understand the flow of steps for each case:
+
+- **Pull Request events**. Applicable to both 'release' and 'next-release'; the steps are the same for both assuming the same PR content:
+
+    1- dorny/paths-filter@v2 checks if English .md files have changed/been added (but doesn't determine whether the script exits or not - see below).
+
+    2- Checks po4a cache (as above).
+
+    3- If the above filter is 'true', update/add .po files with `po4a-update-templates.sh`. If not, skip.
+
+    4- The output from the previous step is never pushed (even if it is 'true') when the trigger is a PR, as this would mean pushing the changes to the contributor's repository, which in turn would require them to enable GitHub actions beforehand. As this cannot be assumed to always be the case, it is left until their PR is merged and then the output is pushed to the Jamulus repository.
+
+    5- Translated .md files are created with `po4a-create-all-targets.sh`.
+
+    6- Site is built, zipped and uploaded as an artifact. This is so the contributor can download and view the site locally, to check translations as they would appear on the website or the overall appearance of the website if other content has been edited (config files, images, etc.) before the PR is merged. Only happens if the trigger was a PR.
+
+- **Push events**. Only applicable to 'next-release':
+
+    1- The 'Paths' filter (not the same filter as the one above) checks if English .md files have changed/been added. If not, the workflow doesn't run at all. As the site is **not** built/zipped/uploaded when merging (it would be identical to the artifact uploaded with the PR event), the target translations don't need to be created either, and therefore no po4a scripts need to be run.
+
+    2- If the above 'Paths' is 'true', the subsequent, separate dorny/paths-filter@v2 filter is also true (it checks for the same changes).
+
+    3- Po4a cache check.
+
+    4- As the above filters are 'true' (otherwise the script wouldn't even run), the .po files are updated/added with `po4a-update-templates.sh`.
+
+    5- The updated/added .po files are pushed to the 'next-release' branch.
+
+    6- In this case, the translated .md files are **not** created, as no zipped/uploaded site will be created and therefore they are not needed.
+
+    7- Site build/zip/upload step is skipped.
+    
+Further information about the translation process itself can be found in `translator-files/README.md`, and about editing English .md files in `wiki/README.md`. More general information about the website processes is contained in the `README` file in the root directory.

--- a/contribute/en/po4a-Setup-Explained.md
+++ b/contribute/en/po4a-Setup-Explained.md
@@ -15,8 +15,8 @@ First though, a brief overview.
 
 In broad terms, there are three types of activity that take place on the website repository:
 
-- Editing/adding/updating translatable documentation in English, the source language that all translations are based on. Translators now need to know _where_ these changes have taken place, preferably without having to actually scan the documents in English or trawl through PRs.
-- Translating these documents into each respective language. As translations now take place in special .po files, these need to be converted back into .md format for the website.
+- Editing/adding/updating translatable documentation in English, the source language that all translations are based on. Translators need to know _where_ these changes have taken place, preferably without having to actually scan the documents in English or trawl through PRs.
+- Translating these documents into each respective language. As translations take place in special .po files, these need to be converted back into .md format for the website.
 - Editing other content in the repository that is not necessarily the documentation itself (scripts, config files, images, etc.). This activity is largely unaffected by the new setup.
 
 So here the focus is on the first two points, as they are what the po4a setup seeks to address, namely:
@@ -92,7 +92,7 @@ This is the more complex script. A distinction between 'pull request' and 'push'
 
     3- If the above filter is 'true', update/add .po files with `po4a-update-templates.sh`. If not, skip.
 
-    4- The output from the previous step is never pushed (even if it is 'true') when the trigger is a PR, as this would mean pushing the changes to the contributor's repository, which in turn would require them to enable GitHub actions beforehand. As this cannot be assumed to always be the case, it is left until their PR is merged and then the output is pushed to the Jamulus repository.
+    4- The output from the previous step is never pushed (even if it is 'true') when the trigger is a PR, as this would mean pushing the changes to the contributor's repository, which in turn would require them to enable GitHub actions beforehand (note: this hasn't been verified). As this cannot be assumed to always be the case, it is left until their PR is merged and then the output is pushed to the Jamulus repository.
 
     5- Translated .md files are created with `po4a-create-all-targets.sh`.
 


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [ *] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

**NOTE**: THIS SHOULD ONLY BE MERGED AFTER #589 IS - OR DISCARD THAT AND DIRECTLY MERGE THIS ONE.

I divided them into 2 PRs to make reviewing easier, but whatever - this one includes all the other PR's changes plus some more.

- Corrected the no-wrap command as the previous one was not working as expected.
- Added command to remove the timestamp line starting with "POT-Creation-Date:" in .po files. This mostly solves the issue of commits being flooded with meaningless edits of this line. Before, this line changed in every single .po file, every time `po4a-update-templates.sh` was run - even if no .po files had been edited. Now, though some editors (namely Poedit) add it back in, it will only happen to the files that are actually edited via translation, vastly reducing the problem. Addresses #521.
- As a consequence of the first point, the list of recommended editors has been reduced to 2 (Poedit and OmegaT), as the rest mess up the line wrapping.
- Made the po4a installation error messages a bit clearer.
- Edited the README and OmegaT instruction files in `_translator-files` to update the instructions regarding the preferred editors.

Leaving this here as I'll be gone until September and will likely not be available in the meantime. The wrapping and timestamp issues were seriously bugging me and I wanted to get them out of the way before leaving.