### PR TITLE
Update 2021-01-05-Jamulus-Sound-Devices.md

### DIFF
--- a/_posts/2021-01-05-Jamulus-Sound-Devices.md
+++ b/_posts/2021-01-05-Jamulus-Sound-Devices.md
@@ -301,7 +301,9 @@ Sounds great, can achieve 32 frame buffer and works on *Windows* and *Linux*.
 
 **[ZOOM LiveTrak L-8](https://zoomcorp.com/en/us/digital-mixer-multi-track-recorders/digital-mixer-recorder/LIVETRAK-L-8/)**, Mixer
 
-**Windows**: ✅ Works. Latency is around 19 ms (measured with local server with ping time of 0 ms) using "L-8 Driver" (ASIO, 07/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads". In the Zoom L-8 Settings ensure that you have the correct Sample Rate - (48kHz) otherwise Jamulus will report that an ASIO Driver error - On the L-8 - Settings switch, toggle to [System] , <push to enter>, toggle to [Sample Rate], <push to enter>, select 48kHz, <push to enter>, "Are you sure?" [Yes] <push to enter>, select Settings switch to complete (doesn't commit till this is done!)
+**NOTE** All OS - In the Zoom L-8 Settings ensure that you have the correct Sample Rate - (48kHz) otherwise Jamulus will report that an ASIO Driver error - On the L-8 - Settings switch, toggle to [System] , <push to enter>, toggle to [Sample Rate], <push to enter>, select 48kHz, <push to enter>, "Are you sure?" [Yes] <push to enter>, select Settings switch to complete (doesn't commit till this is done!)
+
+**Windows**: ✅ Works. Latency is around 19 ms (measured with local server with ping time of 0 ms) using "L-8 Driver" (ASIO, 07/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads". 
 
 **macOS**: ❓ Not yet tested
 

--- a/_posts/2021-01-05-Jamulus-Sound-Devices.md
+++ b/_posts/2021-01-05-Jamulus-Sound-Devices.md
@@ -301,7 +301,7 @@ Sounds great, can achieve 32 frame buffer and works on *Windows* and *Linux*.
 
 **[ZOOM LiveTrak L-8](https://zoomcorp.com/en/us/digital-mixer-multi-track-recorders/digital-mixer-recorder/LIVETRAK-L-8/)**, Mixer
 
-**Windows**: ✅ Works. Latency is around 19 ms (measured with local server with ping time of 0 ms) using "L-8 Driver" (ASIO, 07/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads".
+**Windows**: ✅ Works. Latency is around 19 ms (measured with local server with ping time of 0 ms) using "L-8 Driver" (ASIO, 07/02/2020) from [zoomcorp.com](https://zoomcorp.com/). Driver can be downloaded from link to device and clicking "Support & Downloads". In the Zoom L-8 Settings ensure that you have the correct Sample Rate - (48kHz) otherwise Jamulus will report that an ASIO Driver error - On the L-8 - Settings switch, toggle to [System] , <push to enter>, toggle to [Sample Rate], <push to enter>, select 48kHz, <push to enter>, "Are you sure?" [Yes] <push to enter>, select Settings switch to complete (doesn't commit till this is done!)
 
 **macOS**: ❓ Not yet tested
 


### PR DESCRIPTION
Making sure that the Zoom L-8 is configured to 48kHz to avoid Jamulus ASIO Driver error message

# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [X] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

<!-- A short description of changes you made -->
Additional information regarding Zoom L-8 settings needed to avoid Jamulus ASIO Driver error message