### PR TITLE
Sync scripts in 'release'

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,6 +4,8 @@ on:
     branches: [ next-release, release ]
   push:
     branches: [ next-release ]
+    paths:
+      - 'wiki/en/*.md'
 jobs:
   jekyll_site_ci:
     permissions:
@@ -12,8 +14,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+# Paths changes filter. Detects if there's been a change to any files defined in the filter:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            src_files_changed:
+              - 'wiki/en/*.md'
+
 # Retrieve po4a installation cache or create it if not found:
-      - name: Cache po4a dependencies
+      - name: Check for po4a cache
         uses: actions/cache@v1.0.3
         id: cache-po4a
         with:
@@ -26,42 +37,36 @@ jobs:
 # If CACHE_HIT: true, retrieve the cache. If not, install po4a and its dependencies and copy them all to a folder (~/po4a/) to be cached:
         run: ./_po4a-tools/po4a-cache.sh
 
-# Paths changes filter. Detects if there's been a change to any files defined in the filter:
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            templates:
-              - 'wiki/en/*.md'
-
 # If there have been changes to English .md files in /wiki, run po4a-update-templates:
-      - name: Update templates
-        if: ${{ steps.filter.outputs.templates == 'true' }}
+      - name: Update .po files
+        if: ${{ steps.filter.outputs.src_files_changed == 'true' }}
         run: ./_po4a-tools/po4a-update-templates.sh
 
 # This step only runs if a PR is merged:
-      - name: Push changes to repo if action triggered on:push and templates need updating
-        if: ${{ github.event_name == 'push' && steps.filter.outputs.templates == 'true' }}
+      - name: Push changes to repo if action triggered on:push and .po files need updating
+        if: ${{ github.event_name == 'push' && steps.filter.outputs.src_files_changed == 'true' }}
         uses: EndBug/add-and-commit@v7
         with:
           default_author: github_actions
-          message: 'AUTO: Update templates'
+          message: 'AUTO: Updated .po files'
 
 # Create translated .md files. Never pushed to the repo.
       - name: Create translated .md docs and stats
         run: ./_po4a-tools/po4a-create-all-targets.sh
 
-# Build, zip and upload site
+# Build, zip and upload site only when triggered by PR to avoid duplicating checks and uploads:
       - name: Build the site in the jekyll/builder container
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           docker run \
           -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
           jekyll/builder:latest /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll build --future"
       - name: Zip Website
+        if: ${{ github.event_name == 'pull_request' }}
         run: zip -r ${{ github.workspace }}/website.zip _site/*
       - uses: actions/upload-artifact@v2
         name: Upload Website
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           name: Website
           path: ${{ github.workspace }}/website.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
 # Retrieve po4a installation cache or create it if not found:
-      - name: Cache po4a dependencies
+      - name: Check for po4a cache
         uses: actions/cache@v1.0.3
         id: cache-po4a
         with:
@@ -25,25 +25,25 @@ jobs:
 # If CACHE_HIT: true, retrieve the cache. If not, install po4a and its dependencies and copy them all to a folder (~/po4a/) to be cached:
         run: ./_po4a-tools/po4a-cache.sh
 
-# Paths changes filter. If there's been a change to any files defined in the filter, the step (update templates) runs:
+# Paths changes filter. If there's been a change to any files defined in the filter, the step (update .po files) runs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
           base: ${{ github.ref }}
           filters: |
-            templates:
+            src_files_changed:
               - 'wiki/en/*.md'
-      - name: Update templates
-        if: steps.filter.outputs.templates == 'true'
+      - name: Update .po files
+        if: steps.filter.outputs.src_files_changed == 'true'
         run: ./_po4a-tools/po4a-update-templates.sh
 
 # This step only runs if a PR is merged:
-      - name: Push changes to repo if action triggered on:push and templates need updating
-        if: ${{ steps.filter.outputs.templates == 'true' }}
+      - name: Push changes to repo if action triggered on:push and .po files need updating
+        if: ${{ steps.filter.outputs.src_files_changed == 'true' }}
         uses: EndBug/add-and-commit@v7
         with:
           default_author: github_actions
-          message: 'AUTO: Update templates'
+          message: 'AUTO: Update .po files'
 
 # Create translated .md files. Never pushed to the repo.
       - name: Create translated .md docs and stats

--- a/_po4a-tools/po4a-cache.sh
+++ b/_po4a-tools/po4a-cache.sh
@@ -9,6 +9,9 @@ else
 	sudo apt install -yq gettext libsgmls-perl libyaml-tiny-perl opensp
 	wget -O po4a.deb https://github.com/jamulussoftware/assets/raw/main/po4a/po4a_0.64-alpha.deb
 	sudo dpkg -i po4a.deb
+	if [ -f po4a.deb ]; then
+	    rm po4a.deb
+	fi
 	mkdir -p ~/po4a
 
 for dep in po4a libcroco3 libosp5 sgml-base gettext libsgmls-perl libyaml-tiny-perl opensp; do

--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -16,7 +16,7 @@ cd "$SCRIPT_DIR"
 ####################################
 
 # Set % threshold for translated .md files to be created
-THRESHOLD="80"
+THRESH_VAL="80"
 
 # Folder where source English .md files are
 SRC_DIR="../wiki/en"
@@ -38,19 +38,22 @@ fi
 
 # Check if po4a is installed
 if ! [ -x "$(command -v po4a)" ] ; then
-	echo Error: please install po4a. >&2
+	echo Error: Please install po4a. v0.63 or higher is required >&2
 	exit 1
 fi
 
 # Check if the right version is installed
-if ! [[ $(po4a --version | grep po4a | awk '{print $3}') > 0.63 ]] ; then
-	echo Error: po4a version 0.63 or higher is required. >&2
+PO4A_VER=$(po4a --version | grep po4a | awk '{print $3}')
+
+if [[ $PO4A_VER < 0.63 ]] ; then
+	echo Error: po4a v"$PO4A_VER" is installed >&2
+	echo po4a v0.63 or higher is required. >&2
 	exit 1
 fi
 
 # Check if source document folder exists in the right place
 if ! [ -d "$SRC_DIR" ] ; then
-	echo Error: please run this script from the root folder. >&2
+	echo Error: Please make sure the source English file directory exists. >&2
 	exit 1
 fi
 
@@ -80,6 +83,13 @@ use_po_module () {
 			localized_file="$PUB_DIR/$lang/$basename.md"
 		else
 			localized_file="$PUB_DIR/$lang/$path/$basename.md"
+		fi
+
+		# Exclude certain files from the threshold requirement
+		if [[ "$basename" == 'Shared-'* ]] ; then
+			THRESHOLD="0"
+		else
+			THRESHOLD="$THRESH_VAL"
 		fi
 
 		# Run po4a-translate and create target files


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

The GH actions and po4a scripts on the 'release' branch are out of date. I should have originally updated them in 'release' as they later automatically sync to 'next-release'.
