### PR TITLE
Only create targets on PR

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -52,6 +52,7 @@ jobs:
 
 # Create translated .md files. Never pushed to the repo.
       - name: Create translated .md docs and stats
+        if: ${{ github.event_name == 'pull_request' }}
         run: ./_po4a-tools/po4a-create-all-targets.sh
 
 # Build, zip and upload site only when triggered by PR to avoid duplicating checks and uploads:


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

The script was still unnecessarily creating the target .md files on merges to 'next-release'. See table in #586.
