### PR TITLE
Fix footertext link in Statistics

### DIFF
--- a/_po4a-tools/po4a-stats.sh
+++ b/_po4a-tools/po4a-stats.sh
@@ -3,14 +3,14 @@
 # Creates a statistics file with information on the translation status of each file for every language.
 
 # Stats file location
-STATS_FILE="../contribute/en/Statistics.md"
+STATS_FILE="../wiki/Statistics.md"
 
 # Print yaml front matter and table title/header
 echo '---
 layout: wiki
 title: "Statistics"
 lang: "en"
-permalink: "/contribute/Statistics"
+permalink: "/wiki/Statistics"
 ---
 # Current status of website translations
 

--- a/_translator-files/po/de/Contribution.po
+++ b/_translator-files/po/de/Contribution.po
@@ -55,7 +55,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:15
-msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](/contribute/Statistics)."
+msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](Statistics)."
 msgstr ""
 
 #. type: Plain text

--- a/_translator-files/po/es/Contribution.po
+++ b/_translator-files/po/es/Contribution.po
@@ -46,7 +46,7 @@ msgstr "# Contribuir al Proyecto Jamulus"
 #. type: Plain text
 #: ../wiki/en/Contribution.md:11
 msgid "If you find a mistake, typo or something out of date (in any language) on this website or in Jamulus itself, you can <a href=\"https://github.com/jamulussoftware/jamulus/issues\">raise it as a bug</a>."
-msgstr "Si observas algún error de contenido o tipográfico, o algo que está desfasado (en cualquier idioma) en esta página web o en Jamulus mismo, puedes<a href=\"https://github.com/jamulussoftware/jamulus/issues\">reportarlo como \"bug\"</a>."
+msgstr "Si observas algún error de contenido o tipográfico, o algo que está desfasado (en cualquier idioma) en esta página web o en Jamulus mismo, puedes <a href=\"https://github.com/jamulussoftware/jamulus/issues\">reportarlo como \"bug\"</a>."
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:13

--- a/_translator-files/po/es/Contribution.po
+++ b/_translator-files/po/es/Contribution.po
@@ -55,8 +55,8 @@ msgstr "Si crees que falta o se puede mejorar alguna documentación o informaci�
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:15
-msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](/contribute/Statistics)."
-msgstr "Si quieres ayudar con la traducción, deberás tener una cuenta de GitHub y estar familiarizado con el uso de git y Jekyll. Lee sobre nuestro proceso de [documentación y traducción](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), y [preséntate](https://github.com/jamulussoftware/jamulus/discussions) si te gustaría involucrarte. Puedes comprobar el estado actual de las traducciones de la web [aquí](/contribute/Statistics)."
+msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](Statistics)."
+msgstr "Si quieres ayudar con la traducción, deberás tener una cuenta de GitHub y estar familiarizado con el uso de git y Jekyll. Lee sobre nuestro proceso de [documentación y traducción](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), y [preséntate](https://github.com/jamulussoftware/jamulus/discussions) si te gustaría involucrarte. Puedes comprobar el estado actual de las traducciones de la web [aquí](Statistics)."
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:18

--- a/_translator-files/po/fr/Contribution.po
+++ b/_translator-files/po/fr/Contribution.po
@@ -59,8 +59,8 @@ msgstr "Si vous pensez qu'il manque de la documentation ou des informations ou q
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:15
-msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](/contribute/Statistics)."
-msgstr "Si vous souhaitez aider à la traduction, vous devrez disposer d'un compte GitHub et être familier avec l'utilisation de git et de Jekyll. Lisez notre [processus de documentation et de traduction](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), et [présentez-vous](https://github.com/jamulussoftware/jamulus/discussions) si vous souhaitez vous impliquer. Vous pouvez vérifier l'état actuel des traductions du site web [ici](/contribute/Statistics)."
+msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](Statistics)."
+msgstr "Si vous souhaitez aider à la traduction, vous devrez disposer d'un compte GitHub et être familier avec l'utilisation de git et de Jekyll. Lisez notre [processus de documentation et de traduction](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), et [présentez-vous](https://github.com/jamulussoftware/jamulus/discussions) si vous souhaitez vous impliquer. Vous pouvez vérifier l'état actuel des traductions du site web [ici](Statistics)."
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:18

--- a/_translator-files/po/it/Contribution.po
+++ b/_translator-files/po/it/Contribution.po
@@ -56,7 +56,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:15
-msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](/contribute/Statistics)."
+msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](Statistics)."
 msgstr ""
 
 #. type: Plain text

--- a/_translator-files/po/pt/Contribution.po
+++ b/_translator-files/po/pt/Contribution.po
@@ -55,7 +55,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Contribution.md:15
-msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](/contribute/Statistics)."
+msgid "If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](Statistics)."
 msgstr ""
 
 #. type: Plain text

--- a/wiki/en/Contribution.md
+++ b/wiki/en/Contribution.md
@@ -11,7 +11,7 @@ If you find a mistake, typo or something out of date (in any language) on this w
 
 If you think some documentation or information is missing or can be improved, <a href="https://github.com/jamulussoftware/jamulus/discussions">post about it on this forum</a> so it can be discussed first.
 
-If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](/contribute/Statistics).
+If you want to help out with translation, you will need to have a GitHub account and should be familiar with using git and Jekyll. Read about our [documentation and translation process](https://github.com/jamulussoftware/jamuluswebsite/blob/release/README.md), and [introduce yourself](https://github.com/jamulussoftware/jamulus/discussions) if you’d like to get involved. You can check the current status of website translations [here](Statistics).
 
 
 ## Want to contribute code?


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

Statistics.md now gets created in /wiki/ when the site is deployed. Fixes 
#628 