### PR TITLE
Remove Debian repo instructions

### DIFF
--- a/wiki/en/Installation-for-Linux.md
+++ b/wiki/en/Installation-for-Linux.md
@@ -13,31 +13,16 @@ Make sure you read the [Getting Started](Getting-Started) page.
 
 ### Debian and Ubuntu
 
-#### Debian repository (convenient)
-
-Jamulus is included in the Debian 11 (“bullseye”) repository and can be installed by typing the following in terminal (Open it with e.g. CTRL+ALT+T):
-
-```
-sudo apt update && sudo apt install qjackctl jamulus
-```
-
-This is the easiest and most convenient way to install Jamulus although it won't give you the latest features.
-
-#### Manual install (latest version)
-
-If you want to get the most recent release, you need to install or update Jamulus manually:
-
 1. [Download Jamulus (.deb)]({{ site.download_root_link }}{{ site.download_file_names.deb-gui }}){:.button}
 1. Update apt by opening a console window (CTRL+ALT+T should work) and type: `sudo apt-get update`
-1. Navigate to where you downloaded the installer and either double-click on it, or use the command line: `sudo apt install ./{{ site.download_file_names.deb-gui }}`.
+1. Go to where you downloaded the installer and either double-click on it, or use the command line: `sudo apt install ./{{ site.download_file_names.deb-gui }}`.
 1. Once installed, you can delete the file and close any console windows.
 
 Note that if you need to upgrade Jamulus to a newer version, just download the new .deb file and re-install as above.
 
 ### Other distributions
 
-For installers on other distributions, see their package managers and [Repology](https://repology.org/project/jamulus/versions). If an up to date version of Jamulus is not included in your distribution, you might want to [compile Jamulus from source following the compile guide](https://github.com/jamulussoftware/jamulus/blob/master/COMPILING.md) You may also wish to use one of the contributed [installation scripts](https://github.com/jamulussoftware/installscripts).
-
+For installers on other distributions, see their package managers and [Repology](https://repology.org/project/jamulus/versions). If an up-to-date version of Jamulus is not included in your distribution, you can [compile Jamulus from source](https://github.com/jamulussoftware/jamulus/blob/master/COMPILING.md). Note also the contributed [installation scripts](https://github.com/jamulussoftware/installscripts).
 
 ## Set up your hardware
 


### PR DESCRIPTION
# Does this need translation?

<!-- Does your pull request need translation? -->

- [x] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [ ] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

# Changes

<!-- A short description of changes you made -->

As discussed on Discord - Debian is several versions out of date and unlikely to get much better. See also https://github.com/jamulussoftware/jamuluswebsite/issues/489 TL;DR the **current**, recommended and official way of installing Jamulus on Linux is to download and install the .deb from GH/SF. We don't support any other method, but do point you to Repology and source. Amen.
