### PR TITLE
Layout: Center small-width images properly

### DIFF
--- a/assets/css/wiki.css
+++ b/assets/css/wiki.css
@@ -42,8 +42,12 @@
 }
 
 
+figure {
+    text-align: center;
+}
+
 figure img {
-  display: block;
+  display: inline-block;
   border-radius: 5px;
 }
 


### PR DESCRIPTION
# Changes
Currently, small-width images with captions are left-aligned, while their figcaptions are centered. This looks strange, at least one wider screens (#672).
This PR changes `img`s to `inline-block` and adjusts `figure`s to `text-align` their (inline) content.
Tested on Firefox and Chromium.

## Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

I have therefore opened this PR against the release branch.

## Related issues
<!-- please briefly describe the issue this fixes or link a related GitHub issue if available. -->
Fixes #672