### PR TITLE
Update MIDI usage documentation

### DIFF
--- a/wiki/en/Tips-Tricks-More.md
+++ b/wiki/en/Tips-Tricks-More.md
@@ -82,9 +82,9 @@ Here is the script:
 
 ## Using ctrlmidich for MIDI controllers
 
-The volume fader, pan control and mute and solo buttons in the client's mixer window strips can be controlled using a MIDI controller by using the `--ctrlmidich` parameter (note: only available for use with macOS and Linux using Jamulus version 3.7.0 or higher). To enable this feature, Jamulus must be launched with `--ctrlmidich`. There is one global MIDI channel parameter (1-16) and two parameters you can set for each item controlled: `offset` and `consecutive CC numbers`. Set the first parameter to the channel you want Jamulus to listen on (0 for all channels) and then specify the items you want to control (f = volume fader; p = pan; m = mute; s = solo) with the offset (CC number to start from) and number of consecutive CC numbers. Take the following example:
+The volume fader, pan control and mute and solo buttons in the client's mixer window strips can be controlled using a MIDI controller by using the `--ctrlmidich` parameter (note: only available for use with macOS and Linux using Jamulus version 3.7.0 or higher, and on Windows using the Jamulus version with JACK support). To enable this feature, Jamulus must be launched with `--ctrlmidich`. There is one global MIDI channel parameter (1-16) and two parameters you can set for each item controlled: `offset` and `consecutive CC numbers`. Set the first parameter to the channel you want Jamulus to listen on (0 for all channels) and then specify the items you want to control (f = volume fader; p = pan; m = mute; s = solo) with the offset (CC number to start from) and number of consecutive CC numbers. Take the following example:
 
-`--ctrlmidich '1;f0*8;p16*8;s32*8;m48*8'`
+`--ctrlmidich "1;f0*8;p16*8;s32*8;m48*8"`
 
 Here, Jamulus listens on MIDI channel 1. Volume fader CC numbers start at 0 and there are 8 of them (so end at CC number 7). Pan controls start at CC number 16 and end at 23; Solo 32 to 39 and Mute 48 to 55.
 
@@ -92,5 +92,6 @@ Fader strips in the mixer window are controlled in ascending order from left to 
 
 *Note*: Jamulus does not provide feedback on the state of the Solo and Mute buttons, meaning that your controller must keep track and toggle LEDs (if any) to 'on' or 'off' itself.
 
-Make sure you connect your MIDI device's output port to the Jamulus MIDI in port (QjackCtl (Linux), MIDI Studio (macOS) or whatever you use for managing connections). In Linux you will need to install and launch a2jmidid so your device shows up in the MIDI tab in Qjackctl.
+Make sure you connect your MIDI device's output port to the Jamulus MIDI in port (QjackCtl (Linux/Windows), MIDI Studio (macOS) or whatever you use for managing connections). In Linux you will need to install and launch a2jmidid so your device shows up in the MIDI tab in Qjackctl.
 
+*Tip*: When you enable MIDI control in Jamulus, each user's name is prepended with a number, with the leftmost user starting at 0, then 1, etc. With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. In order to keep the fader strips following a numerical order, go to "View" on the top menu bar and choose "Sort Users by Name".


### PR DESCRIPTION
# Changes

<!-- A short description of changes you made -->


## Does this need translation?

<!-- Does your pull request need translation? -->

- [x] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [ ] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

## Related issues
Related to discussion #2220 where it was pointed out that MIDI controllers can in fact be used with the JACK version for Windows and it was established that it'd be better to use double quotes in the command to avoid issues in Windows. Also added a useful tip for when using MIDI controllers that has been often mentioned but not documented.
