### PR TITLE
Add Link Checker to CI

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -77,6 +77,6 @@ jobs:
         uses: lycheeverse/lychee-action@7c5c1f6e14771e717069e942bbbfed6e13960b92
         with:
           fail: true
-          args: _site/**.html --offline
+          args: _site/**.html _site/**/*.html --offline
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -73,3 +73,10 @@ jobs:
           path: ${{ github.workspace }}/website.zip
           retention-days: 15
           if-no-files-found: error # 'warn' or 'ignore' are also available, defaults to `warn`
+      - name: Check for broken links
+        uses: lycheeverse/lychee-action@7c5c1f6e14771e717069e942bbbfed6e13960b92
+        with:
+          fail: true
+          args: _site/**.html --offline
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Adds a link checker to the CI. This will result in a failed build if there are broken links.

See: 
https://clementbm.github.io/github%20action/jekyll/link%20checking/2020/05/31/automatically-validate-links-on-jekyll-website.html

# Changes

See above


## Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

## Related issues
<!-- please briefly describe the issue this fixes or link a related GitHub issue if available. -->
