### PR TITLE
config: Fix outdated download_root_link which broke all binary downoad URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ parallel_localization:       true
 a_rootpage:                  "https://jamulus.io"
 
 # Jamulus release binary links
-download_root_link:          "https://github.com/jamulussoftware/jamulus/releases/download/r3_8_1/"
+download_root_link:          "https://github.com/jamulussoftware/jamulus/releases/download/r3_8_2/"
 download_file_names:
   deb-gui:                   "jamulus_3.8.2_ubuntu_amd64.deb"
   deb-headless:              "jamulus_headless_3.8.2_ubuntu_amd64.deb"


### PR DESCRIPTION
## Does this need translation?

<!-- Does your pull request need translation? -->

- [ ] Yes <!-- If you tick this, please open a pull request to the changes branch, otherwise to release -->
- [x] No <!-- This is only the case for typos in a specific language or if you changed something for every language -->

## Related issues
<!-- please briefly describe the issue this fixes or link a related GitHub issue if available. -->
Fixes #709