### PR TITLE
Remove separate ARM build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,6 @@ download_file_names:
   windows:                   "jamulus_3.9.0_win.exe"
   windows-jack:              "jamulus_3.9.0_win_jack.exe"
   mac:                       "jamulus_3.9.0_mac.dmg"
-  mac-arm:                   "jamulus_3.9.0_mac_arm64.dmg"
   mac-legacy:                "jamulus_3.9.0_mac_legacy.dmg"
   android:                   "jamulus_3.9.0_android.apk"
   ios:                       "jamulus_3.9.0_iOSUnsigned.ipa"

--- a/wiki/en/Installation-for-Macintosh.md
+++ b/wiki/en/Installation-for-Macintosh.md
@@ -13,22 +13,9 @@ Make sure you've already read the [Getting Started](Getting-Started) page.
 
 Upgrading? You may want to [back up your configuration](Software-Manual#backing-up-jamulus) first.
 
-We provide three downloads for macOS. Please download the appropriate one:
-
-**For macOS running on Intel:**
-
-[Download Jamulus (Intel)]({{ site.download_root_link }}{{ site.download_file_names.mac }}){: .button}
-
-For macOS Mojave (10.14 or lower) please [download the legacy version]({{ site.download_root_link }}{{ site.download_file_names.mac-legacy }})
-
-**For macOS running on Apple Silicon:**
-
-[Download Jamulus (Apple Silicon)]({{ site.download_root_link }}{{ site.download_file_names.mac-arm }}){: .button}
-
+1. [Download Jamulus (Universal build)]({{ site.download_root_link }}{{ site.download_file_names.mac }}){: .button}\\
+ **macOS Mojave (10.14) or lower:** [Download legacy version]({{ site.download_root_link }}{{ site.download_file_names.mac-legacy }})\\
  **Mirror 2:** [SourceForge](https://sourceforge.net/projects/llcon/files/latest/download)
-
-After you downloaded the correct file:
-
 1. **Install Jamulus**: Open the downloaded `.dmg` file, agree to the licence, *drag and drop* each icon you see in the window (Jamulus Client and Server) into your *Applications folder*. After that, you can close this window.
 1. **Run Jamulus**. Now you should be able to use Jamulus just like any other application.
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
As https://github.com/jamulussoftware/jamulus/pull/2808 was merged, we now have a universal build making the need of separate ARM and Intel downloads for macOS unneeded
**Context: Fixes an issue? Related issues**
Related to: https://github.com/jamulussoftware/jamulus/pull/2808
**Status of this Pull Request**
Ready for review
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Review

**Does this need translation?**

YES

## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
