### PR TITLE
Style: Darken TOC in dark mode and move style to fw.css

### DIFF
--- a/assets/css/fw.css
+++ b/assets/css/fw.css
@@ -35,7 +35,7 @@ a:hover {
 }
 
 .blue {
-  color: #1181a4!important;
+  color: #1181a4 !important;
 }
 
 .doubletextsize {
@@ -295,6 +295,22 @@ main>div {
   margin: 0 .3em 0 0;
 }
 
+details {
+  font: 16px;
+  font-style: bold;
+  width: 620px;
+}
+
+details>summary {
+  font-size: 20px;
+  padding: 5px 6px;
+  width: 15em;
+  background-color: #eaf8fd;
+  border: none;
+  color: #1882A1;
+  cursor: pointer;
+}
+
 @media (min-width:940px) {
   #langselect ul li {
     margin: 0 0.3em 0 0;
@@ -336,7 +352,7 @@ main>div {
   }
 
   .blue {
-    color: #3daed2!important;
+    color: #3daed2 !important;
   }
 
   #langselect .selected, #paginator .selected {
@@ -398,9 +414,13 @@ main>div {
     background-color: #2b2f2f;
   }
 
-
   pre code {
     border-left-color: #3daed2;
+  }
+
+  details>summary {
+    background-color: #2b2f2f;
+    color: #3daed2;
   }
 
   .red {
@@ -417,16 +437,16 @@ main>div {
 }
 
 #cc {
-   margin-top: 1.5em;
-   font-style: italic;
-   font-size: 0.75em;
-   color: #696969;
-   clear: both;
+  margin-top: 1.5em;
+  font-style: italic;
+  font-size: 0.75em;
+  color: #696969;
+  clear: both;
 }
 
 #asio-footer {
-   margin-top: 20px;
-   font-style: italic;
-   font-size: 0.75em;
-   clear: both;
+  margin-top: 20px;
+  font-style: italic;
+  font-size: 0.75em;
+  clear: both;
 }

--- a/assets/css/wiki.css
+++ b/assets/css/wiki.css
@@ -14,13 +14,13 @@
 }
 
 .wikisite main h2 {
-   margin-bottom: 0.2em;
-   clear: both;
+  margin-bottom: 0.2em;
+  clear: both;
 }
 
 .wikisite main h3 {
-   margin-bottom: 0.5em;
-   clear: both;
+  margin-bottom: 0.5em;
+  clear: both;
 }
 
 .wikisite #breadcrumb {
@@ -29,12 +29,11 @@
 }
 
 .wikisite .button-container {
-    margin: .25em 0;
+  margin: .25em 0;
 }
 
-
 figure {
-    text-align: center;
+  text-align: center;
 }
 
 figure img {
@@ -49,20 +48,4 @@ figcaption {
   position: relative;
   top: 5px;
   bottom: 10px;
-}
-
-details {
-  font: 16px;
-  font-style: bold;
-  width: 620px;
-}
-
-details > summary {
-  font-size: 20px;
-  padding: 5px 6px;
-  width: 15em;
-  background-color: #eaf8fd;
-  border: none;
-  color: #1882A1;
-  cursor: pointer;
 }


### PR DESCRIPTION


<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Darken TOC background in dark mode. This leads to the following:
![toc](https://user-images.githubusercontent.com/20726856/187997676-550ecfb8-9104-453c-859f-61c938d54771.png)


This also moves the css for details into fw.css as the style is side 
wide and not restricted only to the wiki.

**Context: Fixes an issue? Related issues**
Fixes: https://github.com/jamulussoftware/jamuluswebsite/issues/761

**Status of this Pull Request**
Ready for review. @mulyaj could you please have a look at the contrast?
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Ready for review


**Does this need translation?**

NO


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
