### PR TITLE
--ctrlmidich fix does affect sort by name

### DIFF
--- a/wiki/en/Tips-Tricks-More.md
+++ b/wiki/en/Tips-Tricks-More.md
@@ -96,7 +96,7 @@ Fader strips in the mixer window are controlled in ascending order from left to 
 
 Make sure you connect your MIDI device's output port to the Jamulus MIDI in port (QjackCtl (Linux/Windows), MIDI Studio (macOS) or whatever you use for managing connections). In Linux you will need to install and launch a2jmidid so your device shows up in the MIDI tab in Qjackctl.
 
-*Tip*: When you enable MIDI control in Jamulus, each user's name is prepended with a number, with the leftmost user starting at 0, then 1, etc. With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. In order to keep the fader strips following a numerical order, go to "View" on the top menu bar and choose "Sort Users by Name".
+*Tip*: When you enable MIDI control in Jamulus, each user's name is prepended with a number, with the leftmost user starting at 0, then 1, etc. With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. In order to keep the fader strips following a numerical order, go to "View" on the top menu bar and switch between "No User Sorting" and another option and then back again (e.g. type `Ctrl+N`, `Ctrl+O`).
 
 ## For Server admins
 


### PR DESCRIPTION
**Short description of changes**
Update to **Tips, Tricks and More** to fix the tip for sorting by channel "name" when ctrlmidich is active.  With the fix to prevent the channel number becoming part of the name, it doesn't work, as sort doesn't see the number.

(If sort _should_ see the number, then it will have to be amended to see whether ctrlmidich is active and, if so, prepend the channel number when sorting.)

**Context: Fixes an issue? Related issues**
No documentation issue raised.

**Status of this Pull Request**
Proposal for consideration.

**What is missing until this pull request can be merged?**
Review.  Possibly even more testing to make sure the proposed change really works (did for me).

**Does this need translation?**

YES

## Checklist
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch - I said YES to translations and yes, I have raised the PR against next-release, really I have.
