### PR TITLE
Add infobox for legacy channel fader option

### DIFF
--- a/_includes/infobox_each_os.html
+++ b/_includes/infobox_each_os.html
@@ -1,0 +1,5 @@
+{% if site.data.general.infobox_each_os != '' %}
+<div class="infobox">
+  {{ site.data.general.infobox_each_os }}
+</div>
+{% endif %}

--- a/assets/css/fw.css
+++ b/assets/css/fw.css
@@ -281,6 +281,15 @@ main>div {
   margin: auto;
 }
 
+.infobox {
+  display: inline-block;
+  width: auto;
+  padding: 0.5em;
+  margin: auto;
+  border: solid #49a9c9 2px;
+  border-radius: 5px;
+}
+
 #paginator {
   padding: 0;
   margin: 0;
@@ -395,6 +404,10 @@ details>summary {
 
   .button {
     color: #cecdd2;
+  }
+
+  .infobox {
+    border-color: #3daed2;
   }
 
   :target {

--- a/wiki/en/Installation-for-Android.md
+++ b/wiki/en/Installation-for-Android.md
@@ -12,6 +12,8 @@ permalink: "/wiki/Installation-for-Android"
 
 Make sure you've already read the [Getting Started](Getting-Started) page.
 
+{% include infobox_each_os.html %}
+
 ## Things to note about Android
 
 Although you **can** install Jamulus on Android devices (and hear sound), we strongly recommend **not** doing so. Sound quality - especially over WiFi - is usually bad and latency is high. If you have don't own a PC, we suggest you to buy a [Raspberry Pi](https://www.raspberrypi.org/){: target="_blank" rel="noopener noreferrer" } which is an inexpensive and small device that performs very well with Jamulus. Android support is just a proof of concept.

--- a/wiki/en/Installation-for-Linux.md
+++ b/wiki/en/Installation-for-Linux.md
@@ -11,6 +11,8 @@ permalink: "/wiki/Installation-for-Linux"
 
 Make sure you read the [Getting Started](Getting-Started) page.
 
+{% include infobox_each_os.html %}
+
 Upgrading? You may want to [back up your configuration](Software-Manual#backing-up-jamulus) first.
 
 ### Debian and Ubuntu

--- a/wiki/en/Installation-for-Macintosh.md
+++ b/wiki/en/Installation-for-Macintosh.md
@@ -11,6 +11,8 @@ permalink: "/wiki/Installation-for-Macintosh"
 
 Make sure you've already read the [Getting Started](Getting-Started) page.
 
+{% include infobox_each_os.html %}
+
 Upgrading? You may want to [back up your configuration](Software-Manual#backing-up-jamulus) first.
 
 1. [Download Jamulus (Universal build)]({{ site.download_root_link }}{{ site.download_file_names.mac }}){: .button}\\

--- a/wiki/en/Installation-for-Windows.md
+++ b/wiki/en/Installation-for-Windows.md
@@ -11,6 +11,8 @@ permalink: "/wiki/Installation-for-Windows"
 
 Make sure you read the [Getting Started](Getting-Started) page.
 
+{% include infobox_each_os.html %}
+
 Upgrading? You may want to [back up your configuration](Software-Manual#backing-up-jamulus) first.
 
 1. **Download and install an ASIO Driver**. Try to use the driver that your hardware manufacturer provides. If you can't find that, or you don't have an external sound card, you probably need to install ASIO4ALL. For more information scroll down to the [ASIO](#asio) section.

--- a/wiki/en/Installation-for-iOS.md
+++ b/wiki/en/Installation-for-iOS.md
@@ -12,6 +12,8 @@ permalink: "/wiki/Installation-for-iOS"
 
 Make sure you've already read the [Getting Started](Getting-Started) page.
 
+{% include infobox_each_os.html %}
+
 ## Things to note about iOS
 
 If you have don't own a PC, we suggest you to buy a [Raspberry Pi](https://www.raspberrypi.org/){: target="_blank" rel="noopener noreferrer" } which is an inexpensive and small device that performs very well with Jamulus. iOS support is just a proof of concept.

--- a/wiki/en/misc/general.yml
+++ b/wiki/en/misc/general.yml
@@ -22,3 +22,4 @@ kb:
   discuss:
     title:           "Comments"
     linktitle:       "Discuss this content"
+infobox_each_os:     'Jamulus 3.9.1 addresses a MIDI controller-related bug that could result in the loss of old fader levels: If you used `--ctrlmidich`, you can start the app once with `--cleanuplegacyfadersettings` to try to convert the old format to the new one. This option will be removed in a future release. Read the <a href="https://github.com/jamulussoftware/jamulus/blob/master/ChangeLog">Change Log</a> for more information.'


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Adds a notice to all install pages about `--cleanuplegacyfadersettings`. I think that's the only missing thing for the docs. This message would just stay up until we release the next version. 

![screenshot dark infobox](https://user-images.githubusercontent.com/20726856/193469035-aad26215-cb30-4925-875d-97589b58813d.png)

![screenshot light infobox](https://user-images.githubusercontent.com/20726856/193469056-32b72223-42d2-4211-b067-9c30c5375e22.png)


**Context: Fixes an issue? Related issues**
Related to: https://github.com/jamulussoftware/jamulus/pull/2839


**Status of this Pull Request**
Waiting on review
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Nothing


**Does this need translation?**

YES


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
