### PR TITLE
Remove unneeded trailing slash of void elements

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,19 +2,19 @@
   <div class="fx-col-100-xs fx-col-33-s fx-col-center-xs">
     <a href="https://github.com/jamulussoftware/jamulus" target="_blank" rel="noreferrer">
       <!-- https://icongr.am/fontawesome/github.svg?size=128&color=ffffff -->
-      <img src="{{ '/assets/img/github.svg'| relative_url }}" alt="{{ site.data.general.footer.alt.github }}" loading="lazy" class="fx-center" />
+      <img src="{{ '/assets/img/github.svg'| relative_url }}" alt="{{ site.data.general.footer.alt.github }}" loading="lazy" class="fx-center">
     </a>
   </div>
   <div class="fx-col-100-xs fx-col-33-s fx-col-center-xs">
     <!-- https://icongr.am/fontawesome/facebook-official.svg?size=128&color=ffffff -->
     <a href="https://www.facebook.com/groups/619274602254947/" target="_blank" rel="noreferrer">
-      <img src="{{ '/assets/img/facebook.svg' | relative_url }}" alt="{{ site.data.general.footer.alt.facebook }}" id="fb_icon" loading="lazy" class="fx-center" />
+      <img src="{{ '/assets/img/facebook.svg' | relative_url }}" alt="{{ site.data.general.footer.alt.facebook }}" id="fb_icon" loading="lazy" class="fx-center">
     </a>
   </div>
   <div class="fx-col-100-xs fx-col-33-s fx-col-center-xs">
     <!-- https://icongr.am/fontawesome/comments.svg?size=128&color=ffffff -->
     <a href="https://github.com/jamulussoftware/jamulus/discussions" target="_blank" rel="noreferrer">
-      <img src="{{ '/assets/img/forum.svg' | relative_url }}" alt="{{ site.data.general.footer.alt.help }}" loading="lazy" class="fx-center" />
+      <img src="{{ '/assets/img/forum.svg' | relative_url }}" alt="{{ site.data.general.footer.alt.help }}" loading="lazy" class="fx-center">
     </a>
   </div>
   <div id="copyright" class="fx-col-100-xs fx-row-center-xs">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header class="fx-row fx-row-between-xs fx-text-center">
   <div class="fx-col fx-text-center"><a href="/{% if site.active_lang != site.default_lang %}{{ site.active_lang }}/{% endif %}">
-      <img alt="{{ site.data.general.nav.altJamulusIcon }}" width="40" height="40" src="{{ 'assets/img/jamulus-icon-2020.svg'| relative_url }}" /></a>
+      <img alt="{{ site.data.general.nav.altJamulusIcon }}" width="40" height="40" src="{{ 'assets/img/jamulus-icon-2020.svg'| relative_url }}"></a>
   </div>
   <div class="fx-col-center-xs fx-txt-right hide-on-dt">
     <a href="#mnv" onclick="showNav();return false;">{% include general/navbtn.html %}</a>

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,36 +1,36 @@
-<meta charset="utf-8" />
+<meta charset="utf-8">
 {% for lng in site.languages %}
     {% if lng == site.default_lang %}
       {% capture langlink %}{{ site.a_rootpage }}{{ page.url }}{% endcapture %}
     {% else %}
       {% capture langlink %}{{ site.a_rootpage }}/{{ lng }}{{ page.url }}{% endcapture %}
     {% endif %}
-    <link rel="alternate" hreflang="{{ lng }}" href="{{ langlink }}" />
+    <link rel="alternate" hreflang="{{ lng }}" href="{{ langlink }}">
 {% endfor %}
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link rel="stylesheet" href="/assets/css/fox.min.css" />
-<link rel="stylesheet" href="/assets/css/fw.css" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="stylesheet" href="/assets/css/fox.min.css">
+<link rel="stylesheet" href="/assets/css/fw.css">
 <noscript>
-  <link rel="stylesheet" href="/assets/css/noscript.css" />
+  <link rel="stylesheet" href="/assets/css/noscript.css">
 </noscript>
 <meta name="description" content="{{ page.metadescription }}">
-<link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png" />
-<link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png" />
-<link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png" />
-<link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png" />
-<link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png" />
-<link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png" />
-<link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png" />
-<link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png" />
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png" />
-<link rel="icon" type="image/png" sizes="192x192" href="/android-icon-192x192.png" />
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-<link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png" />
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-<link rel="manifest" href="/manifest.json" />
-<meta name="msapplication-TileColor" content="#ffffff" />
-<meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
-<meta name="theme-color" content="#ffffff" />
-<meta name="color-scheme" content="dark light" />
-<link rel="author" href="/humans.txt" />
+<link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">
+<link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png">
+<link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png">
+<link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png">
+<link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png">
+<link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png">
+<link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png">
+<link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png">
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png">
+<link rel="icon" type="image/png" sizes="192x192" href="/android-icon-192x192.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+<link rel="manifest" href="/manifest.json">
+<meta name="msapplication-TileColor" content="#ffffff">
+<meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
+<meta name="theme-color" content="#ffffff">
+<meta name="color-scheme" content="dark light">
+<link rel="author" href="/humans.txt">
 <script src="/assets/js/nav.js"></script>

--- a/_includes/screenshot.html
+++ b/_includes/screenshot.html
@@ -1,4 +1,4 @@
 <figure>
-   <img src="/assets/img/{{ include.file }}" loading="lazy" style="max-width: {{ include.max-width | default: '100%' }};" alt="{{ include.alt | default: 'Screenshot' }}"/>
+   <img src="/assets/img/{{ include.file }}" loading="lazy" style="max-width: {{ include.max-width | default: '100%' }};" alt="{{ include.alt | default: 'Screenshot' }}">
    <figcaption>{{ include.caption }}</figcaption>
 </figure>

--- a/_layouts/kblist.html
+++ b/_layouts/kblist.html
@@ -15,7 +15,7 @@ pagination:
 <body class="kb kblist">
   <header class="fx-row fx-row-between-xs fx-text-center">
     <div class="fx-col fx-text-center"><a href="/{% if site.active_lang != site.default_lang %}{{ site.active_lang }}/{% endif %}">
-        <img alt="{{ site.data.general.nav.altJamulusIcon }}" width="40" height="40" src="{{ 'assets/img/jamulus-icon-2020.svg'| relative_url }}" /></a>
+        <img alt="{{ site.data.general.nav.altJamulusIcon }}" width="40" height="40" src="{{ 'assets/img/jamulus-icon-2020.svg'| relative_url }}"></a>
     </div>
     <div class="fx-col-center-xs fx-txt-right hide-on-dt">
       <a href="#mnv" onclick="showNav();return false;">{% include general/navbtn.html %}</a>

--- a/_layouts/mainhomepage.html
+++ b/_layouts/mainhomepage.html
@@ -35,7 +35,7 @@
 <body class="mainsite">
   <header class="fx-row fx-row-center-xs">
     <div class="fx-col-100-xs">
-      <img alt="{{ page.mAltProgIcon }}" width="200" height="200" src="{{ '/assets/img/jamulus-icon-2020.svg' | relative_url }}" id="jamulusicon" />
+      <img alt="{{ page.mAltProgIcon }}" width="200" height="200" src="{{ '/assets/img/jamulus-icon-2020.svg' | relative_url }}" id="jamulusicon">
       <h1>Jamulus</h1>
       <span>{{ page.mTSlogan }}</span>
     </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -38,7 +38,7 @@ pagination:
 <body class="kb kbsite">
   <header class="fx-row fx-row-between-xs fx-text-center">
     <div class="fx-col fx-text-center"><a href="/{% if site.active_lang != site.default_lang %}{{ site.active_lang }}/{% endif %}">
-        <img alt="{{ site.data.general.nav.altJamulusIcon }}" width="40" height="40" src="{{ 'assets/img/jamulus-icon-2020.svg'| relative_url }}" /></a>
+        <img alt="{{ site.data.general.nav.altJamulusIcon }}" width="40" height="40" src="{{ 'assets/img/jamulus-icon-2020.svg'| relative_url }}"></a>
     </div>
     <div class="fx-col-center-xs fx-txt-right hide-on-dt">
       <a href="#mnv" onclick="showNav();return false;">{% include general/navbtn.html %}</a>

--- a/_layouts/redirect.html
+++ b/_layouts/redirect.html
@@ -3,9 +3,9 @@
 <html lang="{{ site.active_lang }}">
 
 <head>
-  <meta charset="utf-8" />
-  <meta http-equiv="refresh" content="1;url={{ page.redirect }}" />
-  <link rel="canonical" href="{{ page.redirect }}" />
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="1;url={{ page.redirect }}">
+  <link rel="canonical" href="{{ page.redirect }}">
   <script>
     window.location.href = "{{ page.redirect }}"
   </script>

--- a/wiki/en/misc/1-index.html
+++ b/wiki/en/misc/1-index.html
@@ -43,7 +43,7 @@ mTOtherPlatforms: 'other platforms'
   <div class="fx-col-100-xs fx-col-50-l">
     <h2>Want to get involved?</h2>
     <p>
-    Ideas? Found a bug? Want to contribute some code or help translating into your language? Since Jamulus is <a href="https://www.gnu.org/philosophy/free-sw.en.html" target="_blank" rel="noreferrer" title="What is free software?">free and open source software</a> (FOSS) licensed under the <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html" title="GNU General Public License, version 2" target="_blank" rel="noreferrer">GPL</a>, you can help us!<br/>
+    Ideas? Found a bug? Want to contribute some code or help translating into your language? Since Jamulus is <a href="https://www.gnu.org/philosophy/free-sw.en.html" target="_blank" rel="noreferrer" title="What is free software?">free and open source software</a> (FOSS) licensed under the <a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html" title="GNU General Public License, version 2" target="_blank" rel="noreferrer">GPL</a>, you can help us!<br>
     Take a look at our <a href="wiki/Contribution">contribution guidelines</a> to find out how. Everybody is welcome!
     </p>
     <p>


### PR DESCRIPTION


<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!-- Explain what your PR does -->
HTML void elements should not use trailing slashes:  https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes

This removes (hopefully) all of them
**Context: Fixes an issue? Related issues**
Makes w3c validator happy

**Status of this Pull Request**
Ready for review.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Review


**Does this need translation?**

No.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/master/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
