### PR TITLE
Fix EN doc for po4a

### DIFF
--- a/wiki/en/Include-Shared-Commands.md
+++ b/wiki/en/Include-Shared-Commands.md
@@ -1,14 +1,14 @@
 
 [comment]: # (This is an include file for use in multiple documents)
 
-- `-h` or `--help`           Display help text         
-- `-i` or `--inifile`        Set location of initialization file (overrides default)
-- `-n` or `--nogui`          Disable GUI (for use in headless mode)                      
-- `-p` or `--port`           Sets the local UDP port number. Default is 22124
-- `--jsonrpcport`            Enables JSON-RPC API server to control the app, set TCP port number (EXPERIMENTAL, APIs might change; only accessible from localhost). Please see [the JSON-RPC API Documentation file](https://github.com/jamulussoftware/jamulus/blob/main/docs/JSON-RPC.md).
-- `--jsonrpcsecretfile`      Required when using `--jsonrpcport`. Sets a path to a text file containing an authentication string for getting access to the JSON-RPC API.
-- `--jsonrpcbindip` 		 The IP address the JSON-RPC server should bind to. (optional, defaults to 127.0.0.1)
-- `-Q` or `--qos`            Sets the quality of service DS Field byte. Default is 128 (DSCP/CS4). QoS is ignored by Windows. To enable it, [see this page](QOS-Windows)
-- `-t` or `--notranslation`  Disable UI language translations
-- `-6` or `--enableipv6`     Enable IPv6 addressing (IPv4 is always enabled)
-- `-v` or `--version`        Output version information and exit
+- `-h` or `--help` Display help text
+- `-i` or `--inifile` Set location of initialization file (overrides default)
+- `-n` or `--nogui` Disable GUI (for use in headless mode)
+- `-p` or `--port` Sets the local UDP port number. Default is 22124
+- `--jsonrpcport` Enables JSON-RPC API server to control the app, set TCP port number (EXPERIMENTAL, APIs might change; only accessible from localhost). Please see [the JSON-RPC API Documentation file](https://github.com/jamulussoftware/jamulus/blob/main/docs/JSON-RPC.md).
+- `--jsonrpcsecretfile` Required when using `--jsonrpcport`. Sets a path to a text file containing an authentication string for getting access to the JSON-RPC API.
+- `--jsonrpcbindip` The IP address the JSON-RPC server should bind to. (optional, defaults to 127.0.0.1)
+- `-Q` or `--qos` Sets the quality of service DS Field byte. Default is 128 (DSCP/CS4). QoS is ignored by Windows. To enable it, [see this page](QOS-Windows)
+- `-t` or `--notranslation` Disable UI language translations
+- `-6` or `--enableipv6` Enable IPv6 addressing (IPv4 is always enabled)
+- `-v` or `--version` Output version information and exit


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Those spaces to make the text look aligned cause po4a to group all the strings into a single segment (not sure why). This causes them all to appear as not translated in languages where they actually were, as separate strings (segments).

**Context: Fixes an issue? Related issues**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context (e.g. by linking an issue or pull request from the jamulus repository). -->

**Status of this Pull Request**
The other "Include-*" docs don't have these spaces and are processed correctly by po4a. Not sure why this one is different.

**What is missing until this pull request can be merged?**
Possble objections to changing this formatting.


**Does this need translation?**

Not really. It should restore translations where thay had already been done.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
