### PR TITLE
Fix language tags in 1-index.html if incorrect

### DIFF
--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -128,6 +128,14 @@ process_with_po4a () {
             echo "$filename.$ext" translated into "$lang"
         fi
 
+        # Check if language is set correctly in '1-$lang-index.html'
+        if [ $filename == '1-index' ] ; then
+            if ! grep -Fxq 'lang: "'$lang'"' "$WIKI_DIR/$lang/1-index.html" ; then
+                echo replacing incorrect language tag in 1-"$lang"-index.html;
+                sed -i 's/lang: "[^"]*"/lang: "'$lang'"/' "$WIKI_DIR/$lang/1-index.html"
+            fi
+        fi
+
     done <   <(find -L "$SRC_DIR" -name "*.*"  -print0)
 }
 

--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -132,7 +132,7 @@ process_with_po4a () {
         if [ $filename == '1-index' ] ; then
             if ! grep -Fxq 'lang: "'$lang'"' "$WIKI_DIR/$lang/1-index.html" ; then
                 echo replacing incorrect language tag in 1-"$lang"-index.html;
-                sed -i 's/lang: "[^"]*"/lang: "'$lang'"/' "$WIKI_DIR/$lang/1-index.html"
+                sed -i '0,/lang: "[^"]*"/s/lang: "[^"]*"/lang: "'$lang'"/' "$WIKI_DIR/$lang/1-index.html"
             fi
         fi
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Updated po4a script to check if the language tag is correct in '1-index.html' and correct it if required. Avoids the problem where the website won't build properly if the language is mistyped or left as "en".

**Context: Fixes an issue? Related issues**
Fixes: #918

**Status of this Pull Request**
Should be ready.

**What is missing until this pull request can be merged?**
Tested and works both if the language has been mistyped or left as "en". Does nothing if correct. Might be a more elegant way of doing it though.


**Does this need translation?**

NO.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
