### PR TITLE
Welcome path file access clues

### DIFF
--- a/wiki/en/Running-a-Server.md
+++ b/wiki/en/Running-a-Server.md
@@ -172,6 +172,8 @@ Show an agreement window before users can connect.  The text of the agreement to
 
 ##### `-w or --welcomemessage`
 A "welcome message" to display in the Client chat window on connect. Can be given as a string or filename, and can contain HTML.
+When a path is used, the file must be accessible by the user account running Jamulus. (On most Linux installations, user `jamulus` is used by default.)
+If not accessible, the literal path (rather than its contents) will appear. 
 
 ##### `--serverpublicip`
 The public IP address of the Server if connecting to a Directory behind the same NAT. See [the Directories guide](Directories) for further information.


### PR DESCRIPTION
This PR is a replacement for https://github.com/jamulussoftware/jamuluswebsite/pull/927/

Prior discussion visible at previous PR (now closed).

I believe @ann0see defers to @gilgongo for this PR.

@gilgongo and @pljones articulated concern that all instances of this UX should receive the same guidance, but I don't believe there are other instances of this particular UX, as the others serve error messages, while this one just indicates failure by treating the inaccessible path as a literal string. 