### PR TITLE
Document macOS ini file sandbox requirements

### DIFF
--- a/wiki/en/Include-Shared-Commands.md
+++ b/wiki/en/Include-Shared-Commands.md
@@ -2,7 +2,7 @@
 [comment]: # (This is an include file for use in multiple documents)
 
 - `-h` or `--help` Display help text
-- `-i` or `--inifile` Set location of initialization file (overrides default)
+- `-i` or `--inifile` Set location of initialization file (overrides default. On macOS simply provide a filename only, since config files can only be read from `/Users/<username>/Library/Containers/io.jamulus.Jamulus/Data/`. For the server replace `io.jamulus.Jamulus` with `io.jamulus.JamulusServer`. Turn on "Show Library folder" in "Show view options" in Finder to see this folder.)
 - `-n` or `--nogui` Disable GUI (for use in headless mode)
 - `-p` or `--port` Sets the local UDP port number. Default is 22124
 - `--jsonrpcport` Enables JSON-RPC API server to control the app, set TCP port number (EXPERIMENTAL, APIs might change; only accessible from localhost). Please see [the JSON-RPC API Documentation file](https://github.com/jamulussoftware/jamulus/blob/main/docs/JSON-RPC.md).


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Adds a short description for macOS users where the ini files should be saved to due to the sandbox.

**Context: Fixes an issue? Related issues**

Related to: https://github.com/jamulussoftware/jamulus/issues/2131

<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context (e.g. by linking an issue or pull request from the jamulus repository). -->

**Status of this Pull Request**

Ready for review. Path was verified.

<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Ready for review

**Does this need translation?**
YES
<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
