### PR TITLE
Make "and" on main homepage translatable

### DIFF
--- a/_layouts/mainhomepage.html
+++ b/_layouts/mainhomepage.html
@@ -45,7 +45,7 @@
           <a href="wiki/Getting-Started" id="get_started_btn_top">{{ page.mTGetStartedNow }}</a>
         </div>
         <div class="fx-col-100-xs" id="quick_dl_container">
-          {{ page.mTDownloadNow }} <a href="{{ site.download_root_link }}{{ site.download_file_names.windows }}" target="_blank" rel="noreferrer" class="os-win">Windows</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.mac }}" target="_blank" rel="noreferrer" class="os-mac">macOS</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.deb-gui }}" target="_blank" rel="noreferrer" class="os-deb">Debian/Ubuntu</a> and <a href="{{ site.download_overview_link }}" target="_blank" rel="noreferrer" class="os-other">{{ page.mTOtherPlatforms }}</a>.
+          {{ page.mTDownloadNow }} <a href="{{ site.download_root_link }}{{ site.download_file_names.windows }}" target="_blank" rel="noreferrer" class="os-win">Windows</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.mac }}" target="_blank" rel="noreferrer" class="os-mac">macOS</a>, <a href="{{ site.download_root_link }}{{ site.download_file_names.deb-gui }}" target="_blank" rel="noreferrer" class="os-deb">Debian/Ubuntu</a> {{ page.mTPlatformsAnd }} <a href="{{ site.download_overview_link }}" target="_blank" rel="noreferrer" class="os-other">{{ page.mTOtherPlatforms }}</a>.
         </div>
       </div>
     </div>

--- a/wiki/en/misc/1-index.html
+++ b/wiki/en/misc/1-index.html
@@ -11,6 +11,7 @@ mAltProgIcon: "Jamulus icon"
 mTSlogan: "Play music online. With friends. For free."
 mTGetStartedNow: "Get started now!"
 mTDownloadNow: 'Download now for'
+mTPlatformsAnd: 'and'
 mTOtherPlatforms: 'other platforms'
 ---
 <div class="fx-row fx-row-center-xs" id="firstrow">


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Makes "and" translatable on main homepage

**Context: Fixes an issue? Related issues**
Fixes: #950 

**Status of this Pull Request**
Not yet tested, but will show up on weblate - once I've unlocked it. It works similar to the other translations of the main website.
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
Nothing


**Does this need translation?**
YES
<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
