### PR TITLE
no sudo means password failure on cert-based aws instance

### DIFF
--- a/wiki/en/Running-a-Server.md
+++ b/wiki/en/Running-a-Server.md
@@ -73,7 +73,7 @@ To run a headless server on Linux, the following steps assume you are familiar w
 
 	`sudo systemctl daemon-reload && sudo systemctl restart jamulus-headless`
 
-_To change your Server configuration, just repeat the last two steps above._
+_To edit your Server configuration, just repeat the last two steps above._
 
 ---
 

--- a/wiki/en/Running-a-Server.md
+++ b/wiki/en/Running-a-Server.md
@@ -71,9 +71,9 @@ To run a headless server on Linux, the following steps assume you are familiar w
 
 1. Reload the systemd files and restart the headless Server:
 
-	`sudo systemctl daemon-reload && systemctl restart jamulus-headless`
+	`sudo systemctl daemon-reload && sudo systemctl restart jamulus-headless`
 
-_To amend your Server configuration, just repeat the last two steps above._
+_To change your Server configuration, just repeat the last two steps above._
 
 ---
 


### PR DESCRIPTION
In this PR I add **sudo** to the second command of the compound bash line. Without this, I'm asked for a password on aws cert-based Ubuntu. With it, all is well. But I can't confirm this is best practice in all cases. Can you?

I also change _amend_ to _change_ as amending has a specific meaning that probably doesn't apply here.

