### PR TITLE
Add canonical links for Google

### DIFF
--- a/_includes/general/nav.html
+++ b/_includes/general/nav.html
@@ -1,12 +1,20 @@
 <aside id="gnav" class="fx-col-100-xs fx-col-25-m">
   {% if page.hidelang %}{% else %}{% include langselect.html %}{% endif %}
+
+<!--
+Default lang is: {{ site.default_lang }}
+Current lang is: {{ page.lang }}
+-->
+
+  {% if page.lng == site.default_lang %} {% comment %} Not sure why this isn't true for en. {% endcomment %} 
+  
   <nav id="mnv">
     <ul>
       {% if site.data.navigation.nav[0] %}
       {% for item in site.data.navigation.nav %}
       {% if item.url %}
       <li>
-        <h3><a href="{{ item.url | relative_url }}" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ item.title }}</a></h3>
+        <h3><a href="{{ item.url | relative_url }}" rel="canonical" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ item.title }}</a></h3>
       {% else %}
       <li>
         <h3>{{ item.title }}</h3>
@@ -14,11 +22,11 @@
       {% if item.subfolderitems[0] %}
         <ul>
           {% for entry in item.subfolderitems %}
-          <li><a href="{{ entry.url }}" class="{% if entry.url == page.url or entry.selectOnLayout == page.layout %}selected{% endif %}">{{ entry.page }}</a>
+          <li><a href="{{ entry.url }}"  rel="canonical" class="{% if entry.url == page.url or entry.selectOnLayout == page.layout %}selected{% endif %}">{{ entry.page }}</a>
             {% if entry.subsubfolderitems[0] %}
             <ul>
               {% for subentry in entry.subsubfolderitems %}
-              <li><a href="{{ subentry.url }}" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ subentry.page }}</a></li>
+              <li><a href="{{ subentry.url }}"  rel="canonical" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ subentry.page }}</a></li>
               {% endfor %}
             </ul>
             {% endif %}
@@ -31,5 +39,43 @@
       {% endif %}
     </ul>
 	<div id="cc">{{ site.data.copyright.nav.docs }}</div>
-  </nav>
+ </nav>
+
+ {% else %}
+
+   <nav id="mnv">
+    <ul>
+      {% if site.data.navigation.nav[0] %}
+      {% for item in site.data.navigation.nav %}
+      {% if item.url %}
+      <li>
+        <h3><a href="{{ item.url | relative_url }}" rel="alternate" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ item.title }}</a></h3>
+      {% else %}
+      <li>
+        <h3>{{ item.title }}</h3>
+      {% endif %}
+      {% if item.subfolderitems[0] %}
+        <ul>
+          {% for entry in item.subfolderitems %}
+          <li><a href="{{ entry.url }}" rel="alternate" class="{% if entry.url == page.url or entry.selectOnLayout == page.layout %}selected{% endif %}">{{ entry.page }}</a>
+            {% if entry.subsubfolderitems[0] %}
+            <ul>
+              {% for subentry in entry.subsubfolderitems %}
+              <li><a href="{{ subentry.url }}" rel="alternate" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ subentry.page }}</a></li>
+              {% endfor %}
+            </ul>
+            {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+      </li>
+      {% endif %}
+      {% endfor %}
+      {% endif %}
+    </ul>
+        <div id="cc">{{ site.data.copyright.nav.docs }}</div>
+ </nav>
+
+{% endif %}
+
 </aside>

--- a/_includes/general/nav.html
+++ b/_includes/general/nav.html
@@ -6,7 +6,7 @@ Default lang is: {{ site.default_lang }}
 Current lang is: {{ page.lang }}
 -->
 
-  {% if page.lng == site.default_lang %} {% comment %} Not sure why this isn't true for en. {% endcomment %} 
+  {% if page.lang == site.default_lang %} {% comment %} Not sure why this isn't true for en. {% endcomment %} 
   
   <nav id="mnv">
     <ul>

--- a/_includes/general/nav.html
+++ b/_includes/general/nav.html
@@ -1,15 +1,13 @@
 <aside id="gnav" class="fx-col-100-xs fx-col-25-m">
   {% if page.hidelang %}{% else %}{% include langselect.html %}{% endif %}
-
-  {% if page.lang == site.default_lang %}
-  
   <nav id="mnv">
     <ul>
       {% if site.data.navigation.nav[0] %}
       {% for item in site.data.navigation.nav %}
       {% if item.url %}
       <li>
-        <h3><a href="{{ item.url | relative_url }}" rel="canonical" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ item.title }}</a></h3>
+      {% if page.lang == site.default_lang %}{% capture lang_rel %}canonical{% endcapture %}{% else %}{% capture lang_rel %}alternate{% endcapture %}{% endif %}
+        <h3><a href="{{ item.url | relative_url }}" rel="{{ lang_rel }}" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ item.title }}</a></h3>
       {% else %}
       <li>
         <h3>{{ item.title }}</h3>
@@ -17,46 +15,13 @@
       {% if item.subfolderitems[0] %}
         <ul>
           {% for entry in item.subfolderitems %}
-          <li><a href="{{ entry.url }}"  rel="canonical" class="{% if entry.url == page.url or entry.selectOnLayout == page.layout %}selected{% endif %}">{{ entry.page }}</a>
+            {% if page.lang == site.default_lang %}{% capture lang_rel %}canonical{% endcapture %}{% else %}{% capture lang_rel %}alternate{% endcapture %}{% endif %}
+            <li><a href="{{ entry.url }}" lang="{{ lang_rel }}" class="{% if entry.url == page.url or entry.selectOnLayout == page.layout %}selected{% endif %}">{{ entry.page }}</a>
             {% if entry.subsubfolderitems[0] %}
             <ul>
-              {% for subentry in entry.subsubfolderitems %}
-              <li><a href="{{ subentry.url }}"  rel="canonical" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ subentry.page }}</a></li>
-              {% endfor %}
-            </ul>
-            {% endif %}
-          </li>
-          {% endfor %}
-        </ul>
-      </li>
-      {% endif %}
-      {% endfor %}
-      {% endif %}
-    </ul>
-	<div id="cc">{{ site.data.copyright.nav.docs }}</div>
- </nav>
-
- {% else %}
-
-   <nav id="mnv">
-    <ul>
-      {% if site.data.navigation.nav[0] %}
-      {% for item in site.data.navigation.nav %}
-      {% if item.url %}
-      <li>
-        <h3><a href="{{ item.url | relative_url }}" rel="alternate" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ item.title }}</a></h3>
-      {% else %}
-      <li>
-        <h3>{{ item.title }}</h3>
-      {% endif %}
-      {% if item.subfolderitems[0] %}
-        <ul>
-          {% for entry in item.subfolderitems %}
-          <li><a href="{{ entry.url }}" rel="alternate" class="{% if entry.url == page.url or entry.selectOnLayout == page.layout %}selected{% endif %}">{{ entry.page }}</a>
-            {% if entry.subsubfolderitems[0] %}
-            <ul>
-              {% for subentry in entry.subsubfolderitems %}
-              <li><a href="{{ subentry.url }}" rel="alternate" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ subentry.page }}</a></li>
+          {% for subentry in entry.subsubfolderitems %}
+              {% if page.lang == site.default_lang %}{% capture lang_rel %}canonical{% endcapture %}{% else %}{% capture lang_rel %}alternate{% endcapture %}{% endif %}
+              <li><a href="{{ subentry.url }}"  lang="{{ lang_rel }}" class="{% if subentry.url == page.url or subentry.selectOnLayout == page.layout %}selected{% endif %}">{{ subentry.page }}</a></li>
               {% endfor %}
             </ul>
             {% endif %}
@@ -69,8 +34,5 @@
       {% endif %}
     </ul>
         <div id="cc">{{ site.data.copyright.nav.docs }}</div>
- </nav>
-
-{% endif %}
-
+  </nav>
 </aside>

--- a/_includes/general/nav.html
+++ b/_includes/general/nav.html
@@ -1,12 +1,7 @@
 <aside id="gnav" class="fx-col-100-xs fx-col-25-m">
   {% if page.hidelang %}{% else %}{% include langselect.html %}{% endif %}
 
-<!--
-Default lang is: {{ site.default_lang }}
-Current lang is: {{ page.lang }}
--->
-
-  {% if page.lang == site.default_lang %} {% comment %} Not sure why this isn't true for en. {% endcomment %} 
+  {% if page.lang == site.default_lang %}
   
   <nav id="mnv">
     <ul>

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -2,10 +2,11 @@
 {% for lng in site.languages %}
     {% if lng == site.default_lang %}
       {% capture langlink %}{{ site.a_rootpage }}{{ page.url }}{% endcapture %}
+          <link rel="canonical" hreflang="{{ lng }}" href="{{ langlink }}">
     {% else %}
       {% capture langlink %}{{ site.a_rootpage }}/{{ lng }}{{ page.url }}{% endcapture %}
+          <link rel="alternate" hreflang="{{ lng }}" href="{{ langlink }}">
     {% endif %}
-    <link rel="alternate" hreflang="{{ lng }}" href="{{ langlink }}">
 {% endfor %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="/assets/css/fox.min.css">

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -7,7 +7,7 @@
       {% else %}
         {% if lng == site.default_lang %}
           {% capture langlink %} {{ page.url }}{% endcapture %}
-          <li><a href="{{ langlink }}" rel="canonical" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
+          {% capture lang_rel %}canonical{% endcapture %}
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
            <li><a href="{{ langlink }}"  rel="alternate" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -11,7 +11,7 @@
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
           {% capture lang_rel %}alternate{% endcapture %}
-          {% endif %}
+        {% endif %}
           <li><a href="{{ langlink }}" rel="{{ lang_rel }}" data-slang="{{ lng }}">{{ lng }}</a></li>
       {% endif %}
     {% endfor %}

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -8,9 +8,11 @@
         {% if lng == site.default_lang %}
           {% capture langlink %} {{ page.url }}{% endcapture %}
           {% capture lang_rel %}canonical{% endcapture %}
+          <li><a href="{{ langlink }}" rel="{{ lang_rel }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
           {% capture lang_rel %}alternate{% endcapture %}
+          <li><a href="{{ langlink }}" rel="{{ lang_rel }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -10,7 +10,7 @@
           <li><a href="{{ langlink }}" rel="canonical" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
-           <li><a href="{{ langlink }}" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
+           <li><a href="{{ langlink }}"  rel="alternate" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -10,7 +10,7 @@
           {% capture lang_rel %}canonical{% endcapture %}
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
-           <li><a href="{{ langlink }}"  rel="alternate" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
+          {% capture lang_rel %}alternate{% endcapture %}
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -7,10 +7,11 @@
       {% else %}
         {% if lng == site.default_lang %}
           {% capture langlink %} {{ page.url }}{% endcapture %}
+          <li><a href="{{ langlink }}" rel="canonical" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
+           <li><a href="{{ langlink }}" hreflang="{{ lng }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% endif %}
-        <li><a href="{{ langlink }}" data-slang="{{ lng }}">{{ lng }}</a></li>
       {% endif %}
     {% endfor %}
   </ul>

--- a/_includes/langselect.html
+++ b/_includes/langselect.html
@@ -8,12 +8,11 @@
         {% if lng == site.default_lang %}
           {% capture langlink %} {{ page.url }}{% endcapture %}
           {% capture lang_rel %}canonical{% endcapture %}
-          <li><a href="{{ langlink }}" rel="{{ lang_rel }}" data-slang="{{ lng }}">{{ lng }}</a></li>
         {% else %}
           {% capture langlink %}/{{ lng }}{{ page.url }}{% endcapture %}
           {% capture lang_rel %}alternate{% endcapture %}
+          {% endif %}
           <li><a href="{{ langlink }}" rel="{{ lang_rel }}" data-slang="{{ lng }}">{{ lng }}</a></li>
-        {% endif %}
       {% endif %}
     {% endfor %}
   </ul>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -28,10 +28,10 @@ category: hidden
       </url>
     {% endunless %}
   {% endfor %}
-  {% for post in site.posts %}
+  {% for post in site.posts %} {% comment %}Hard-coded URL here as variable wasn't working.{% endcomment %}
     {% unless post.published == false %}
       <url>
-        <loc>{{ site.url }}{{ post.url }}</loc>
+        <loc>https://jamulus.io{{ post.url }}</loc>
         <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.5</priority>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -28,10 +28,10 @@ category: hidden
       </url>
     {% endunless %}
   {% endfor %}
-  {% for post in site.posts %} {% comment %}Hard-coded URL here as variable wasn't working.{% endcomment %}
+  {% for post in site.posts %}
     {% unless post.published == false %}
       <url>
-        <loc>https://jamulus.io{{ post.url }}</loc>
+        <loc>{{ site.a_rootpage }}{{ post.url }}</loc>
         <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.5</priority>


### PR DESCRIPTION
==> **UPDATE** <===

These changes are probably better incorporated with @ignotus666 changes to the language selector. So putting in draft for now.

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

1. Fix for https://github.com/jamulussoftware/jamuluswebsite/issues/986
3. Adds fully-qualified links to KB articles in `sitemap.xml`  which I think might be responsible for "invalid URL" errors from Google.

**What is missing until this pull request can be merged?**
~~Ideally, need to work out how to get `_includes/general/nav.html ` to work, but it's not doing it when the current language is en for some reason.~~

BTW I'm not 100% sure that adding `rel=canonical` to the EN version of links is necessarily going to fix Google's problem, since they imply we can only "suggest" the canonical versions, but hopefully this will make things a bit better.


**Does this need translation?**

No


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch

