### PR TITLE
Identify canonical and alternate URLs

### DIFF
--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 <!-- Canonical and Alternate Links -->
 {% comment %}
-English URLs don't have a lang subdirectory (exact reason unkown):
+English URLs don't have a lang subdirectory since it's the default language:
 {% endcomment %}
     <link rel="canonical" hreflang="en" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
 {% for lng in site.languages | sort %}

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,6 +1,9 @@
 <meta charset="utf-8">
 <!-- Canonical and Alternate Links -->
-<link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
+{% comment %}
+English URLs don't have a lang subdirectory (exact reason unkown):
+{% endcomment %}
+   <link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -36,4 +36,3 @@
 <meta name="color-scheme" content="dark light">
 <link rel="author" href="/humans.txt">
 <script src="/assets/js/nav.js"></script>
-gilgongo@desk:~$

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,14 +1,13 @@
 <meta charset="utf-8">
 <!-- Canonical and Alternate Links -->
+<link rel="canonical" hreflang="en" href="https://jamulus.io{{ page.url }}">
 {% assign sorted_languages = site.languages | sort %}
 {% for lng in sorted_languages %}
-  {% if lng == site.default_lang %}
-    <link rel="canonical" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
+  {% if lng == site.active_lang %}
   {% else %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">
   {% endif %}
 {% endfor %}
-<link rel="alternate" hreflang="x-default" href="{{ site.url }}/{{ page.url }}">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="/assets/css/fox.min.css">
 <link rel="stylesheet" href="/assets/css/fw.css">
@@ -37,3 +36,4 @@
 <meta name="color-scheme" content="dark light">
 <link rel="author" href="/humans.txt">
 <script src="/assets/js/nav.js"></script>
+gilgongo@desk:~$

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -3,7 +3,7 @@
 {% comment %}
 English URLs don't have a lang subdirectory (exact reason unkown):
 {% endcomment %}
-   <link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
+    <link rel="canonical" hreflang="en" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,8 +1,7 @@
 <meta charset="utf-8">
 <!-- Canonical and Alternate Links -->
 <link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
-{% assign sorted_languages = site.languages | sort %}
-{% for lng in sorted_languages %}
+{% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">
   {% endif %}

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,7 +1,8 @@
 <meta charset="utf-8">
 <!-- Canonical and Alternate Links -->
 {% comment %}
-English URLs don't have a lang subdirectory since it's the default language:
+English URLs don't have a lang subdirectory since it's the default language.
+See https://github.com/untra/polyglot
 {% endcomment %}
     <link rel="canonical" hreflang="en" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
 {% for lng in site.languages | sort %}

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -1,10 +1,9 @@
 <meta charset="utf-8">
 <!-- Canonical and Alternate Links -->
-<link rel="canonical" hreflang="en" href="https://jamulus.io{{ page.url }}">
+<link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
 {% assign sorted_languages = site.languages | sort %}
 {% for lng in sorted_languages %}
-  {% if lng == site.active_lang %}
-  {% else %}
+  {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">
   {% endif %}
 {% endfor %}

--- a/wiki/en/misc/1-index.md
+++ b/wiki/en/misc/1-index.md
@@ -28,7 +28,7 @@ Jamulus lets you play, rehearse, or jam with your friends, your band, or anyone 
 <div class="fx-row fx-row-center-xs" id="bannercontainer">
   <div class="fx-col-100-xs">
     <figure class="mainbannerfig">
-      <a href="wiki/Getting-Started" rel="canonical">
+      <a href="wiki/Getting-Started">
       <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing five people from different countries connected.">
       </a>
       <figcaption>Jamulus is international</figcaption>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

_(The Google docs on this are confusing because they also address things that don't apply to us, so I hope I have the following right!)_

**Short description of changes**
<!-- Explain what your PR does -->
We regard the English version of a page as always being the canonical version. So no other languages should be marked as canonical URLs to content that also exits in English. Alternate URLs are other language versions of the English content.

**Context**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context (e.g. by linking an issue or pull request from the jamulus repository). -->

This should fix an issue which (I think!) Google has when one or more URLs have similar content. For example, if https://jamulus/[lang]/wiki/Installation-for-Linux is partially translated, we need to tell Google that it should regard https://jamulus/wiki/Installation-for-Linux as the canonical version.  **NOTE**: It's possible that this problem was a symptom of us not having correct `hreflang` codes, but using these `rel` tags seems to be best practice in our case. 

Removed a "rel=canonical" tag from the index pages because we should not put that outside of the HTML head. 

Also removed the `x-default-hreflang`, as we [don't have a language-switching](https://developers.google.com/search/blog/2013/04/x-default-hreflang-for-international-pages?authuser=0) page.




**Does this need translation?**

May need to update the language index pages? Otherwise no?

<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
