### PR TITLE
Add closing / to standalone HTML tags, for po4a parser.

### DIFF
--- a/wiki/en/misc/1-index.md
+++ b/wiki/en/misc/1-index.md
@@ -29,7 +29,7 @@ Jamulus lets you play, rehearse, or jam with your friends, your band, or anyone 
   <div class="fx-col-100-xs">
     <figure class="mainbannerfig">
       <a href="wiki/Getting-Started">
-      <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing five people from different countries connected.">
+      <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing five people from different countries connected."/>
       </a>
       <figcaption>Jamulus is international</figcaption>
     </figure>
@@ -53,10 +53,10 @@ You can also ask on the [forums](https://github.com/jamulussoftware/jamulus/disc
     <h2>Want to get involved?</h2>
     <p>
 <div markdown="1">
-Ideas? Found a bug? Want to contribute some code or help [translating](https://github.com/jamulussoftware/jamulus/blob/main/docs/TRANSLATING.md) Jamulus into your language? Since Jamulus is [free and open source software](https://www.gnu.org/philosophy/free-sw.en.html) (FOSS) licensed under the [GPL](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) you can help us!<br>
-<br>
-Take a look at our [contribution guidelines](wiki/Contribution) to find out how. Everybody is welcome!<br>
-<br>
+Ideas? Found a bug? Want to contribute some code or help [translating](https://github.com/jamulussoftware/jamulus/blob/main/docs/TRANSLATING.md) Jamulus into your language? Since Jamulus is [free and open source software](https://www.gnu.org/philosophy/free-sw.en.html) (FOSS) licensed under the [GPL](https://www.gnu.org/licenses/old-licenses/gpl-2.0.en.html) you can help us!<br/>
+<br/>
+Take a look at our [contribution guidelines](wiki/Contribution) to find out how. Everybody is welcome!<br/>
+<br/>
 _For detailed information on how Jamulus works, see [this paper by Volker Fischer (PDF)](/PerformingBandRehearsalsontheInternetWithJamulus.pdf)._
 </div>
     </p>


### PR DESCRIPTION

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!-- Explain what your PR does -->
The po4a XML parser seems to dislike standalone HTML tags such as `<img>` and `<br>`, and this causes it to mis-parse tags that enclose them.

This commit changes them to self-closing tags, `<img>` to `<img/>` and `<br>` to `<br/>`, which keeps the XML parser happy.

**Context: Fixes an issue? Related issues**
<!-- If this fixes an issue, please write Fixes: <issue number here>; if not, please give your PR a context (e.g. by linking an issue or pull request from the jamulus repository). -->
Discovered while testing Jekyll on Ubuntu 24

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->
Ready

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->
Nothing

**Does this need translation?**
No

<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
