### PR TITLE
Fix for jekyll canonical URL construction

### DIFF
--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -4,7 +4,7 @@
 English URLs don't have a lang subdirectory since it's the default language.
 See https://github.com/untra/polyglot
 {% endcomment %}
-    <link rel="canonical" hreflang="en" href="{{ site.url }}{{ site.baseurl }}/{{page.name}}">
+    <link rel="canonical" hreflang="en" href="{{ site.url }}/{{page.name}}">
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -4,7 +4,7 @@
 English URLs don't have a lang subdirectory since it's the default language.
 See https://github.com/untra/polyglot
 {% endcomment %}
-    <link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
+    <link rel="canonical" hreflang="en" href="{{ site.url }}{{ site.baseurl }}/{{page.name}}">
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -4,7 +4,7 @@
 English URLs don't have a lang subdirectory since it's the default language.
 See https://github.com/untra/polyglot
 {% endcomment %}
-    <link rel="canonical" hreflang="en" href="{{ site.url }}{{ site.baseurl }}{{ page.url }}">
+    <link rel="canonical" hreflang="en" href="{{ site.url }}{{ page.url }}">
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -4,15 +4,7 @@
 English URLs don't have a lang subdirectory since it's the default language.
 See https://github.com/untra/polyglot
 {% endcomment %}
-    <link rel="canonical" hreflang="en" href="{{ site.url }}{{page.url}}">
-<!--
-        version {{ jekyll.version }}
-        site.url {{ site.url }}
-        site.baseurl {{ site.baseurl }} - seems not to exist?
-        page.url {{ page.url }}
-        page.dir {{ page.dir }}
-        page.path {{ page.path }}
--->
+    <link rel="canonical" hreflang="en" {% static_href %}href="{{ page.url }}"{% endstatic_href %}>
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
     <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}/{{ lng }}{{ page.url }}">

--- a/_includes/headtags.html
+++ b/_includes/headtags.html
@@ -4,10 +4,18 @@
 English URLs don't have a lang subdirectory since it's the default language.
 See https://github.com/untra/polyglot
 {% endcomment %}
-    <link rel="canonical" hreflang="en" href="{{ site.url }}/{{page.name}}">
+    <link rel="canonical" hreflang="en" href="{{ site.url }}{{page.url}}">
+<!--
+        version {{ jekyll.version }}
+        site.url {{ site.url }}
+        site.baseurl {{ site.baseurl }} - seems not to exist?
+        page.url {{ page.url }}
+        page.dir {{ page.dir }}
+        page.path {{ page.path }}
+-->
 {% for lng in site.languages | sort %}
   {% if lng != "en" %}
-    <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}{{ site.baseurl }}/{{ lng }}{{ page.url }}">
+    <link rel="alternate" hreflang="{{ lng }}" href="{{ site.url }}/{{ lng }}{{ page.url }}">
   {% endif %}
 {% endfor %}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This is to test whether the .zip version of the site renders the same as that of a local build, since we spotted a possible issue with that in with https://github.com/jamulussoftware/jamuluswebsite/pull/1026

EDIT: Turned out that it was a quirk of the Jekyll Polyglot plugin that was only apparent when running `jekyll build`.
