### PR TITLE
Fix inconsistent "Software Manual" references

### DIFF
--- a/wiki/en/Client-Troubleshooting.md
+++ b/wiki/en/Client-Troubleshooting.md
@@ -46,7 +46,7 @@ If you hear two claps after step 2, or any claps after step 4, then you are **no
 
 Exactly how you avoid listening to your direct signal will depend on your individual setup - your sound interface, mixing desk, headphone connection point, etc. For example, some audio interfaces have "monitor" buttons (turn these off), or similar options. **If you are still having problems**, try asking on the [forum](https://github.com/jamulussoftware/jamulus/discussions).
 
-Be aware that while listening to the Server's signal will ensure you will be in sync with other musicians, you may also experience problems if your overall latency (indicated by the "Delay" light in Jamulus) is not green or at least yellow most of the time. Consult the [software manual](/wiki/Software-Manual) to understand how to adjust your setup to help with this.
+Be aware that while listening to the Server's signal will ensure you will be in sync with other musicians, you may also experience problems if your overall latency (indicated by the "Delay" light in Jamulus) is not green or at least yellow most of the time. Consult the [User Manual](/wiki/Software-Manual) to understand how to adjust your setup to help with this.
 
 ### Can't work out your mic settings?
 
@@ -105,4 +105,4 @@ Maybe you did not answer "Yes" to the `"Jamulus wants to access your microphone"
 
 ***
 
-For anything else, please search or post on the [Discussion Forums](https://github.com/jamulussoftware/jamulus/discussions)
+For anything else, please search or post on the [Discussion Forums](https://github.com/jamulus/jamulus/discussions)

--- a/wiki/en/Client-Troubleshooting.md
+++ b/wiki/en/Client-Troubleshooting.md
@@ -105,4 +105,4 @@ Maybe you did not answer "Yes" to the `"Jamulus wants to access your microphone"
 
 ***
 
-For anything else, please search or post on the [Discussion Forums](https://github.com/jamulus/jamulus/discussions)
+For anything else, please search or post on the [Discussion Forums](https://github.com/orgs/jamulussoftware/discussions)

--- a/wiki/en/Getting-Started.md
+++ b/wiki/en/Getting-Started.md
@@ -84,7 +84,7 @@ If you don’t want others to hear your audio, click on the “Mute Myself” bu
 
 Note that you can use the Chat facility at any time to message other people while you are connected. The welcome message in the chat may also state some guidelines for use.
 
-More information about using Jamulus can be found in the [Software Manual](/wiki/Software-Manual).
+More information about using Jamulus can be found in the [User Manual](/wiki/Software-Manual).
 
 ## Troubleshooting
 

--- a/wiki/en/Software-Manual.md
+++ b/wiki/en/Software-Manual.md
@@ -1,10 +1,10 @@
 ---
 layout: wiki
-title: "Software Manual"
+title: "User Manual"
 lang: "en"
 permalink: "/wiki/Software-Manual"
 ---
-# Jamulus User Manual
+# User Manual
  {:.no_toc}
 
 This manual documents the Jamulus Client application for use by musicians and singers using the software to connect to a server.


### PR DESCRIPTION
Fixes some issues as per https://github.com/jamulussoftware/jamuluswebsite/issues/1030

**Does this need translation?**

Yes


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
