### PR TITLE
Make <img> in 1-Index-html translatable

### DIFF
--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -106,7 +106,7 @@ process_with_po4a () {
             OPTION=("skip_array")
         elif [[ $ext == html || "$filename" == *'-index' ]] ; then # '-index.md' has a markdown extension but is actually html and should be processed as such by po4a
             FILE_FORMAT=xml
-            OPTION=("ontagerror=silent" "attributes=<img>src <img>alt")
+            OPTION=("ontagerror=warn" "attributes=<img>src <img>alt")
         elif [ $ext == md ] ; then
             FILE_FORMAT=text
             OPTION=("markdown")

--- a/_po4a-tools/po4a-create-all-targets.sh
+++ b/_po4a-tools/po4a-create-all-targets.sh
@@ -99,16 +99,17 @@ process_with_po4a () {
             THRESHOLD="$THRESH_VAL"
         fi
 
-        # Determine file format to be used
+        # Determine file format to be used and set options (configured as an array to allow adding an arbitrary number of them)
+        OPTION=()
         if [ $ext == yml ] ; then
             FILE_FORMAT=yaml
-            OPTION="skip_array"
+            OPTION=("skip_array")
         elif [[ $ext == html || "$filename" == *'-index' ]] ; then # '-index.md' has a markdown extension but is actually html and should be processed as such by po4a
             FILE_FORMAT=xml
-            OPTION="ontagerror=warn"
+            OPTION=("ontagerror=silent" "attributes=<img>src <img>alt")
         elif [ $ext == md ] ; then
             FILE_FORMAT=text
-            OPTION="markdown"
+            OPTION=("markdown")
         fi
 
         # Run po4a-translate and create target files
@@ -120,7 +121,7 @@ process_with_po4a () {
             --localized "$targ_doc" \
             --localized-charset "UTF-8" \
             --no-deprecation \
-            --option "$OPTION" \
+            "${OPTION[@]/#/--option=}" \
             --keep "$THRESHOLD"
 
         # Display message if translated file is created

--- a/_po4a-tools/po4a-update-templates.sh
+++ b/_po4a-tools/po4a-update-templates.sh
@@ -60,16 +60,17 @@ while IFS= read -r -d '' doc ; do
             echo creating "$po_file"
         fi
 
-        # Determine file format to be used
+        # Determine file format to be used and set options (configured as an array to allow adding an arbitrary number of them)
+        OPTION=()
         if [ $ext == yml ] ; then
             FILE_FORMAT=yaml
-            OPTION="skip_array"
+            OPTION=("skip_array")
         elif [[ $ext == html || "$filename" == *'-index' ]] ; then # '-index.md' has a markdown extension but is actually html and should be processed as such by po4a
             FILE_FORMAT=xml
-            OPTION="ontagerror=warn"
+            OPTION=("ontagerror=silent" "attributes=<img>src <img>alt")
         elif [ $ext == md ] ; then
             FILE_FORMAT=text
-            OPTION="markdown"
+            OPTION=("markdown")
         fi
 
         # Update/create .po files
@@ -80,7 +81,7 @@ while IFS= read -r -d '' doc ; do
             --msgmerge-opt  --no-wrap \
             --wrap-po newlines \
             --no-deprecation \
-            --option "$OPTION" \
+            "${OPTION[@]/#/--option=}" \
             --po "$po_file" ; then
         echo ''
         echo Error updating "$lang" PO file for: "$filename".$ext
@@ -103,3 +104,4 @@ for lang in $(ls "$PO_DIR") ; do
     # Delete line in file header that pollutes commits
     sed -i '/^"POT-Creation-Date:/d' $PO_DIR/$lang/*.po
 done
+

--- a/_po4a-tools/po4a-update-templates.sh
+++ b/_po4a-tools/po4a-update-templates.sh
@@ -67,7 +67,7 @@ while IFS= read -r -d '' doc ; do
             OPTION=("skip_array")
         elif [[ $ext == html || "$filename" == *'-index' ]] ; then # '-index.md' has a markdown extension but is actually html and should be processed as such by po4a
             FILE_FORMAT=xml
-            OPTION=("ontagerror=silent" "attributes=<img>src <img>alt")
+            OPTION=("ontagerror=warn" "attributes=<img>src <img>alt")
         elif [ $ext == md ] ; then
             FILE_FORMAT=text
             OPTION=("markdown")
@@ -104,4 +104,3 @@ for lang in $(ls "$PO_DIR") ; do
     # Delete line in file header that pollutes commits
     sed -i '/^"POT-Creation-Date:/d' $PO_DIR/$lang/*.po
 done
-

--- a/wiki/en/misc/1-index.md
+++ b/wiki/en/misc/1-index.md
@@ -29,7 +29,7 @@ Jamulus lets you play, rehearse, or jam with your friends, your band, or anyone 
   <div class="fx-col-100-xs">
     <figure class="mainbannerfig">
       <a href="wiki/Getting-Started">
-      <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing five people from different countries connected."/>
+      <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing several people from different countries connected."/>
       </a>
       <figcaption>Jamulus is international</figcaption>
     </figure>

--- a/wiki/en/misc/1-index.md
+++ b/wiki/en/misc/1-index.md
@@ -29,7 +29,7 @@ Jamulus lets you play, rehearse, or jam with your friends, your band, or anyone 
   <div class="fx-col-100-xs">
     <figure class="mainbannerfig">
       <a href="wiki/Getting-Started">
-      <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing several people from different countries connected."/>
+      <img src="{% include img/en-screenshots/main-screen-medium.inc %}" style="border: 5px solid grey;" id="jamulusbanner" loading="lazy" alt="A screenshot of the main mixer window showing five people from different countries connected."/>
       </a>
       <figcaption>Jamulus is international</figcaption>
     </figure>


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
This adds an option to the po4a script to make the content of the `<img>` tag translatable - it was being skipped by po4a and made it impossible to show localised screenshots of the main mixer window on the homepage. It also makes it possible to easily add an arbitrary number of options in future if needed.

**Context: Fixes an issue? Related issues**
This problem was pointed out by @henkdegroot on Discord.

**Status of this Pull Request**
Tested and working

**What is missing until this pull request can be merged?**
Any Weblate PRs have to be merged first.


**Does this need translation?**

NO.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I'm sure that this Pull Request goes to the correct branch
