### PR TITLE
--ctrlmidich improved documentation

### DIFF
--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -2,5 +2,5 @@
 - `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)                                                      
 -  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`  
 -  `-j` or `--nojackconnect`  Disable auto JACK connections  
--  `--ctrlmidich`  MIDI controller channel to listen on, control number offset and consecutive CC numbers (channels) and Mute Myself CC number. Format: `channel[;f*][;p*][;s*][;m*][;o]` See [Tips & Tricks](Tips-Tricks-More#using-ctrlmidich-for-midi-controllers)
+-  `--ctrlmidich`  MIDI controller channel to listen on, MIDI control number and count of consecutive CC numbers (Jamulus channels), Mute Myself CC number and "My Channel" option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;z]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name

--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -2,5 +2,5 @@
 - `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)                                                      
 -  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`  
 -  `-j` or `--nojackconnect`  Disable auto JACK connections  
--  `--ctrlmidich`  MIDI controller channel to listen on, MIDI control number and count of consecutive CC numbers (Jamulus channels), Mute Myself CC number and "My Channel" option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;z]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
+-  `--ctrlmidich`  MIDI controller channel to listen on, MIDI control number and count of consecutive CC numbers (Jamulus channels), Mute Myself CC number and device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name

--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -2,5 +2,5 @@
 - `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)                                                      
 -  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`  
 -  `-j` or `--nojackconnect`  Disable auto JACK connections  
--  `--ctrlmidich`  MIDI controller channel to listen on, MIDI control number and count of consecutive CC numbers (Jamulus channels), Mute Myself CC number and device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
+-  `--ctrlmidich`  MIDI channel to listen on, Jamulus control + MIDI control number and count of consecutive CC numbers (or Jamulus channels), device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name

--- a/wiki/en/Tips-Tricks-More.md
+++ b/wiki/en/Tips-Tricks-More.md
@@ -119,7 +119,7 @@ When using JACK or macOS, make sure you connect your MIDI device's output port t
 2. The long form is a sequence of offsets and counts for various controllers:
 
    ```
-   [MIDI channel];[control letter][offset](*[count](;...))
+   [MIDI channel];[control letter][offset](*[count])(;...)
    ```
 
    * `MIDI channel` is required or else the parameter argument is ignored and the feature is not active.  `0` means "any channel", `1`-`16` listen only to MIDI messages on the specified MIDI channel.

--- a/wiki/en/Tips-Tricks-More.md
+++ b/wiki/en/Tips-Tricks-More.md
@@ -84,7 +84,7 @@ Here is the script:
 
 The volume fader, pan control and mute and solo buttons in the Client's mixer window strips can be controlled using a connected MIDI controller. This feature is available from version 3.7.0 on macOS, Linux, and the JACK version of Jamulus for Windows. From Jamulus 3.12.0 onwards, it is also available for the non-JACK (ASIO) Windows version.  To enable this feature, Jamulus must be launched with the `--ctrlmidich` command-line option.
 
-When this option is used on the command line, Jamulus will prepend a channel number to each Client name, which can be used to control the channel using MIDI CC numbers. In Jamulus version 3.12.0 onwards, when connected to a server of at least version 3.5.5, your own fader will always be given channel 0, and so will appear first when unsorted or sorted by channel, whether or not "Own Fader First" is enabled.
+When this option is used on the command line, Jamulus will prepend a channel number to each Client name, which can be used to control the channel using MIDI CC numbers. In Jamulus version 3.12.0 onwards, when connected to a server of at least version 3.5.5, your own fader will always be given channel 0, and so will appear first when sorted by channel or when "Own Fader First" is enabled.
 
 *Tip*: With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. To keep the fader strips following a numerical order, go to "View" on the top menu bar and switch to "Sort by Channel" (or type `Ctrl+E`).
 


### PR DESCRIPTION
**Short description of changes**

https://github.com/jamulussoftware/jamulus/pull/3394 adds a new feature to the `--ctrlmidich` option to allow binding a MIDI CC number explicitly to the participant's "own" channel on the server, regardless of the assigned channel number.

This required some changes to the documentation to explain how it worked.  I took the opportunity to clarify (hopefully) the detailed information in Tips & Tricks.

**Context: Fixes an issue? Related issues**

See https://github.com/jamulussoftware/jamulus/pull/3394

**Status of this Pull Request**

Looks okay locally.

**What is missing until this pull request can be merged?**

Needs reviewing and shouldn't be merged until after https://github.com/jamulussoftware/jamulus/pull/3394

**Does this need translation?**

YES


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I'm sure that this Pull Request goes to the correct branch
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
