### PR TITLE
Pin CI runner to Ubuntu 22 for now

### DIFF
--- a/.github/workflows/add-lang.yml
+++ b/.github/workflows/add-lang.yml
@@ -7,7 +7,7 @@ jobs:
     permissions:
       contents: write
       issues: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.label.name == 'new language'
     steps:
 

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -11,7 +11,7 @@ jobs:
   jekyll_site_ci:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   build_and_deploy_site:
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -107,7 +107,7 @@ jobs:
     needs: build_and_deploy_site
     permissions:
       contents: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: ${{ github.sha }} update from release


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Changes the runners for the website CI from `ubuntu-latest` to `ubuntu-22.04` explicitly.

**Context: Fixes an issue? Related issues**
While working on #1053, I discovered that Github had very recently updated `ubuntu-latest` to use Ubuntu 24 instead of Ubuntu 22. For some reason as yet unknown, the CI Jekyll build fails on Ubuntu 24. Probably to do with tool versions.

In order for builds not to fail while this is being investigated, this PR fixes the runner at the working Ubuntu 22.

**Status of this Pull Request**
Ready to merge.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->


**Does this need translation?**
No
<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
