### PR TITLE
Remove "(Universal)" from macOS download

### DIFF
--- a/wiki/en/Installation-for-Macintosh.md
+++ b/wiki/en/Installation-for-Macintosh.md
@@ -15,7 +15,7 @@ Make sure you've already read the [Getting Started](Getting-Started) page.
 
 Upgrading? You may want to [back up your configuration](Software-Manual#backing-up-jamulus) first.
 
-1. [Download Jamulus (Universal build)]({{ site.download_root_link }}{{ site.download_file_names.mac }}){: .button}\\
+1. [Download Jamulus]({{ site.download_root_link }}{{ site.download_file_names.mac }}){: .button}\\
  **Mirror 2:** [SourceForge](https://sourceforge.net/projects/llcon/files/latest/download)
 1. **Install Jamulus**: Open the downloaded `.dmg` file, agree to the licence, *drag and drop* each icon you see in the window (Jamulus Client and Server) into your *Applications folder*. After that, you can close this window.
 1. **Run Jamulus**. Now you should be able to use Jamulus just like any other application.


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Since Jamulus has been available for Arm and Intel for a while now on macOS, we don't need to specifically mention "Universal" anymore in my opinion. This doesn't mean we should drop intel support any time soon.

**Context: Fixes an issue? Related issues**
No

**Status of this Pull Request**
Ready for review
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->

Nothing
**Does this need translation?**
YES
<!-- Does your pull request need translation? If you type "YES", please open a pull request to the next-release branch, otherwise to release. Usually, Pull Requests to release are only for typos in a specific language or if you changed something for every language -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I'm sure that this Pull Request goes to the correct branch
