### PR TITLE
Update MIDI docs for GUI tab

### DIFF
--- a/assets/img/de-screenshots/settings-midi.inc
+++ b/assets/img/de-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/de-screenshots/settings-midi.inc
+++ b/assets/img/de-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/en-screenshots/settings-midi.inc
+++ b/assets/img/en-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/en-screenshots/settings-midi.inc
+++ b/assets/img/en-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/es-screenshots/settings-midi.inc
+++ b/assets/img/es-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/es-screenshots/settings-midi.inc
+++ b/assets/img/es-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/fr-screenshots/settings-midi.inc
+++ b/assets/img/fr-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/fr-screenshots/settings-midi.inc
+++ b/assets/img/fr-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/ko-KR-screenshots/settings-midi.inc
+++ b/assets/img/ko-KR-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/ko-KR-screenshots/settings-midi.inc
+++ b/assets/img/ko-KR-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/nb-NO-screenshots/settings-midi.inc
+++ b/assets/img/nb-NO-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/nb-NO-screenshots/settings-midi.inc
+++ b/assets/img/nb-NO-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/nl-screenshots/settings-midi.inc
+++ b/assets/img/nl-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/nl-screenshots/settings-midi.inc
+++ b/assets/img/nl-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/pt-BR-screenshots/settings-midi.inc
+++ b/assets/img/pt-BR-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/pt-BR-screenshots/settings-midi.inc
+++ b/assets/img/pt-BR-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/pt-PT-screenshots/settings-midi.inc
+++ b/assets/img/pt-PT-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/pt-PT-screenshots/settings-midi.inc
+++ b/assets/img/pt-PT-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/ru-screenshots/settings-midi.inc
+++ b/assets/img/ru-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/ru-screenshots/settings-midi.inc
+++ b/assets/img/ru-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/sv-SE-screenshots/settings-midi.inc
+++ b/assets/img/sv-SE-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/sv-SE-screenshots/settings-midi.inc
+++ b/assets/img/sv-SE-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/th-screenshots/settings-midi.inc
+++ b/assets/img/th-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/th-screenshots/settings-midi.inc
+++ b/assets/img/th-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/assets/img/zh-CN-screenshots/settings-midi.inc
+++ b/assets/img/zh-CN-screenshots/settings-midi.inc
@@ -1,1 +1,1 @@
-https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095
+https://github.com/user-attachments/assets/2f14110c-5e73-4416-b8dc-f326fe3b5f3d

--- a/assets/img/zh-CN-screenshots/settings-midi.inc
+++ b/assets/img/zh-CN-screenshots/settings-midi.inc
@@ -1,0 +1,1 @@
+https://github.com/user-attachments/assets/b1b07b0d-e5e7-4704-a7ae-17bc18004095

--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -1,6 +1,6 @@
-- `-M` or `--mutestream`  Prevent others on a server from hearing what I play                                                      
-- `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)                                                      
--  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`  
--  `-j` or `--nojackconnect`  Disable auto JACK connections  
--  `--ctrlmidich`  MIDI channel to listen on, Jamulus control + MIDI control number and count of consecutive CC numbers (or Jamulus channels), device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
+- `-M` or `--mutestream`  Prevent others on a server from hearing what I play
+- `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)
+-  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`
+-  `-j` or `--nojackconnect`  Disable auto JACK connections
+-  `--ctrlmidich`  MIDI channel to listen on, Jamulus control + MIDI control number and count of consecutive CC numbers (or Jamulus channels), pick-up mode, device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;u][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name

--- a/wiki/en/Software-Manual.md
+++ b/wiki/en/Software-Manual.md
@@ -173,7 +173,7 @@ Sorts by the instrument or city someone has in their profile, along with their n
 * Sort by Group<br/>
 Where the fader group feature is in use, this sorts in ascending group number from left to right (and within that, by name), with any ungrouped channels off to the right.
 * Sort by Channel<br/>
-Where Jamulus channel controls (fader, mute, solo, etc) are being controlled by MIDI (see [Using --ctrlmidich for MIDI controllers](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers)), this sorts by the channel number to help ensure a stable sort order that aligns with MIDI hardware controls.
+Where Jamulus channel controls (fader, mute, solo, etc) are being controlled by MIDI (see [MIDI control](#midi-control)), this sorts by the channel number to help ensure a stable sort order that aligns with MIDI hardware controls.
 Note that in Jamulus clients before version 3.12.0, channel numbers are assigned directly by the server. Clients from 3.12.0 onwards manage their own channel number assignments and always assign channel 0 to the local user (provided the server version is at least 3.5.5).
 
 ### View > Chat
@@ -337,6 +337,28 @@ Attempts to detect audio feedback loops or loud noise in the first three seconds
 Controls the relative levels of the left and right local audio channels. For a mono signal
 it acts as a pan between the two channels. For example, if a microphone is connected to the right input channel and
 an instrument is connected to the left input channel which is much louder than the microphone, move the audio fader to increase the relative volume of the mic.
+
+## MIDI Control
+
+<figure><img src="{% include img/en-screenshots/settings-midi.inc %}" style="border: 5px solid grey;" loading="lazy" alt="Image of MIDI control window"></figure>
+
+The volume fader, pan control and mute and solo buttons in the Client's mixer window strips can be controlled using a connected MIDI controller. This feature is available from version 3.7.0 on macOS, Linux, and the JACK version of Jamulus for Windows. From Jamulus 3.12.0 onwards, it is also available for the non-JACK (ASIO) Windows version. To enable this feature and open a MIDI-in port, activate the "MIDI-in" checkbox.
+
+When using Linux or macOS, make sure you connect your MIDI device's output port to the Jamulus MIDI in port (QjackCtl (Linux/Windows), Audio/MIDI Setup (macOS) or whatever you use for managing connections). If using QjackCtl in Linux you may need to install and launch `a2jmidid` so your device shows up in the MIDI tab. For non-JACK Windows, Jamulus will find the MIDI device(s) automatically, but [see the `d` command line option](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers) if more than one MIDI device is connected.
+
+There is one global MIDI channel parameter (0-16) and two parameters you can set for each item controlled: First MIDI CC and consecutive CC numbers (count). First set the channel you want Jamulus to listen on (0 for all channels). Then, for each item you want to control (volume fader, pan, solo, mute), set the first MIDI CC (CC number to start from) and number of consecutive CC numbers (count) you wish to assign to that particular item. You can either type in the MIDI CC values or use the "Learn" button: click on "Learn", actuate the fader/knob/button on your MIDI controller, and the MIDI CC number will be detected and saved.
+
+As an example, a 'First MIDI CC' of 0 and a 'Count' of 8 for volume faders will mean that CC numbers 0 - 7 will control the volume faders for up to 8 mixer channels.
+
+There is one exception that does not require establishing consecutive CC numbers which is the “Mute Myself” parameter - it only requires a single CC number as it is only applied to one’s own audio stream.
+
+*Note*: Jamulus does not provide feedback on the on/off state of buttons, meaning that your controller must keep track and toggle LEDs (if any) to 'on' or 'off' itself, that is, buttons on your MIDI controller need to be set to "toggle" mode. This means that when pressed to 'turn on' a control, it must send a MIDI CC number with a value >=64, and to 'turn off' the control it must send the same CC number with a value <64. You can read your controller's manual to find out how to set this.
+
+When MIDI is enabled, Jamulus will prepend a channel number to each Client name, which can be used to control the channel using MIDI CC numbers. In Jamulus version 3.12.0 onwards, when connected to a server of at least version 3.5.5, your own fader will always be given channel 0, and so will appear first when sorted by channel or when "Own Fader First" is enabled.
+
+*Tip*: With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. To keep the fader strips following a numerical order, go to "View" on the top menu bar and switch to "Sort by Channel" (or type `Ctrl+E`).
+
+
 
 # Backing up Jamulus
 

--- a/wiki/en/Software-Manual.md
+++ b/wiki/en/Software-Manual.md
@@ -344,7 +344,11 @@ an instrument is connected to the left input channel which is much louder than t
 
 The volume fader, pan control and mute and solo buttons in the Client's mixer window strips can be controlled using a connected MIDI controller. This feature is available from version 3.7.0 on macOS, Linux, and the JACK version of Jamulus for Windows. From Jamulus 3.12.0 onwards, it is also available for the non-JACK (ASIO) Windows version. To enable this feature and open a MIDI-in port, activate the "MIDI-in" checkbox.
 
-When using Linux or macOS, make sure you connect your MIDI device's output port to the Jamulus MIDI in port (QjackCtl (Linux/Windows), Audio/MIDI Setup (macOS) or whatever you use for managing connections). If using QjackCtl in Linux you may need to install and launch `a2jmidid` so your device shows up in the MIDI tab. For non-JACK Windows, Jamulus will find the MIDI device(s) automatically, but [see the `d` command line option](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers) if more than one MIDI device is connected.
+### MIDI Device
+
+With MIDI-in enabled, Jamulus will detect the MIDI devices available for connection and list them in the 'MIDI Device' dropdown menu. Select the device you wish to connect to Jamulus. The non-JACK Windows version of Jamulus will automatically connect to all available MIDI devices if none have been selected previously or a saved device is not present. To connect to a single device, select it from the dropdown.
+
+### MIDI parameters
 
 There is one global MIDI channel parameter (0-16) and two parameters you can set for each item controlled: First MIDI CC and consecutive CC numbers (count). First set the channel you want Jamulus to listen on (0 for all channels). Then, for each item you want to control (volume fader, pan, solo, mute), set the first MIDI CC (CC number to start from) and number of consecutive CC numbers (count) you wish to assign to that particular item. You can either type in the MIDI CC values or use the "Learn" button: click on "Learn", actuate the fader/knob/button on your MIDI controller, and the MIDI CC number will be detected and saved.
 
@@ -352,13 +356,16 @@ As an example, a 'First MIDI CC' of 0 and a 'Count' of 8 for volume faders will 
 
 There is one exception that does not require establishing consecutive CC numbers which is the “Mute Myself” parameter - it only requires a single CC number as it is only applied to one’s own audio stream.
 
+### Pick-up Mode
+
+When enabled, fader and pan controls will wait for your physical controller to match their value before moving. This prevents sudden jumps when they are out of sync.
+
+
 *Note*: Jamulus does not provide feedback on the on/off state of buttons, meaning that your controller must keep track and toggle LEDs (if any) to 'on' or 'off' itself, that is, buttons on your MIDI controller need to be set to "toggle" mode. This means that when pressed to 'turn on' a control, it must send a MIDI CC number with a value >=64, and to 'turn off' the control it must send the same CC number with a value <64. You can read your controller's manual to find out how to set this.
 
 When MIDI is enabled, Jamulus will prepend a channel number to each Client name, which can be used to control the channel using MIDI CC numbers. In Jamulus version 3.12.0 onwards, when connected to a server of at least version 3.5.5, your own fader will always be given channel 0, and so will appear first when sorted by channel or when "Own Fader First" is enabled.
 
 *Tip*: With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. To keep the fader strips following a numerical order, go to "View" on the top menu bar and switch to "Sort by Channel" (or type `Ctrl+E`).
-
-
 
 # Backing up Jamulus
 

--- a/wiki/en/Tips-Tricks-More.md
+++ b/wiki/en/Tips-Tricks-More.md
@@ -82,7 +82,7 @@ Here is the script:
 
 ### Using `--ctrlmidich` for MIDI controllers
 
-MIDI controller parameters can be set using the `--ctrlmidich` command-line option. Bear in mind that when used it will overwrite any values set previously via the GUI. Any values not set in the command line will be reverted to defaults (0 for offset/first MIDI CC and 1 for count).
+MIDI controller parameters can be set using the `--ctrlmidich` command-line option. Bear in mind that when used, specified control parameters will overwrite any values set previously using the GUI. Any controls not set in the command line will be disabled, though their values will be preserved.
 
 `--ctrlmidich` takes a single argument. If you omit it, the parameter is ignored. There are two formats for the argument:
 
@@ -92,7 +92,7 @@ MIDI controller parameters can be set using the `--ctrlmidich` command-line opti
    [MIDI channel];[offset for first fader]
    ```
 
-   * `MIDI channel` is required or else the parameter argument is ignored and the feature is not active.  `0` means "any channel", `1`-`16` listen only to MIDI messages on the specified MIDI channel.
+   * `MIDI channel` is required or else the parameter argument is ignored and the feature is not active. `0` means "any channel", `1`-`16` listen only to MIDI messages on the specified MIDI channel.
 
    * `offset for first fader` is the first MIDI CC to use to control a Jamulus Channel fader, with all MIDI CCs after that being used; must be a number or else the long form is used.
 
@@ -116,7 +116,7 @@ MIDI controller parameters can be set using the `--ctrlmidich` command-line opti
    [MIDI channel];[control letter][offset](*[count])(;...)
    ```
 
-   * `MIDI channel`
+   * `MIDI channel` is required or else the parameter argument is ignored and the feature is not active. `0` means "any channel", `1`-`16` listen only to MIDI messages on the specified MIDI channel.
 
    * `control letter` defines which Jamulus Control the MIDI controller number is assigned to:
 
@@ -143,17 +143,19 @@ MIDI controller parameters can be set using the `--ctrlmidich` command-line opti
    --ctrlmidich "0;f0*8;p16*8;s32*8;m48*8"
    ```
 
-   * Two additional `control letter` values are available:
+   * Three additional `control letter` values are available:
 
      1. `o` controls Mute Myself and has a single `offset` (i.e. `count` is ignored and taken as 1).
 
-     2. `d` is an option on Windows non-JACK Jamulus to specify a particular MIDI input device by name -- without this, all devices will be assigned to Jamulus; with it, only the specified device will be used.  For example:
+     2. `u` enables `MIDI Pick-up Mode` for the fader and pan controls.
+
+     3. `d` is an option to specify a particular MIDI input device by name -- without this, it is up to the user to make connections with a connection manager or by other means, and on Windows non-JACK Jamulus all devices will be assigned to Jamulus; with it, only the specified device will be used. For example:
 
         ```
         --ctrlmidich "1;f0*8;dnanoKontrol"
         ```
 
-        would listen for CC0 through CC7 on MIDI channel 1 from a MIDI device called "nanoKontrol".  Remember to wrap the whole of the `--ctrlmidich` argument in double quotes and you will have no problems with device names containing spaces.
+        would listen for CC0 through CC7 on MIDI channel 1 from a MIDI device called "nanoKontrol". Remember to wrap the whole of the `--ctrlmidich` argument in double quotes and you will have no problems with device names containing spaces.
 
         In order to discover the correct device name to use, start Jamulus from the command line with `--ctrlmidich` and observe the output. Jamulus will list all discovered MIDI devices:
 
@@ -173,9 +175,9 @@ MIDI controller parameters can be set using the `--ctrlmidich` command-line opti
           1: Keystation Mini 32 (ignored)
         ```
 
-	Note that if only one MIDI device is connected, the `d` option is not necessary, as Jamulus will use the device automatically.
+	Note that for Windows non-JACK Jamulus if only one MIDI device is connected, the `d` option is not necessary, as Jamulus will use the device automatically.
 
-	On macOS, Linux or Windows with JACK, the `d` option is accepted if given, but ignored.
+	For more information about using MIDI devices with Jamulus, see the [MIDI control](Software-Manual#midi-control) section in the Software Manual.
 
 ## For Server admins
 

--- a/wiki/en/Tips-Tricks-More.md
+++ b/wiki/en/Tips-Tricks-More.md
@@ -82,15 +82,9 @@ Here is the script:
 
 ### Using `--ctrlmidich` for MIDI controllers
 
-The volume fader, pan control and mute and solo buttons in the Client's mixer window strips can be controlled using a connected MIDI controller. This feature is available from version 3.7.0 on macOS, Linux, and the JACK version of Jamulus for Windows. From Jamulus 3.12.0 onwards, it is also available for the non-JACK (ASIO) Windows version.  To enable this feature, Jamulus must be launched with the `--ctrlmidich` command-line option.
+MIDI controller parameters can be set using the `--ctrlmidich` command-line option. Bear in mind that when used it will overwrite any values set previously via the GUI. Any values not set in the command line will be reverted to defaults (0 for offset/first MIDI CC and 1 for count).
 
-When this option is used on the command line, Jamulus will prepend a channel number to each Client name, which can be used to control the channel using MIDI CC numbers. In Jamulus version 3.12.0 onwards, when connected to a server of at least version 3.5.5, your own fader will always be given channel 0, and so will appear first when sorted by channel or when "Own Fader First" is enabled.
-
-*Tip*: With default settings, when some users leave and others join, their left-right arrangement in the GUI may cease to follow a numerical order, making it more difficult to know who each physical fader/knob on your MIDI controller corresponds to. To keep the fader strips following a numerical order, go to "View" on the top menu bar and switch to "Sort by Channel" (or type `Ctrl+E`).
-
-When using JACK or macOS, make sure you connect your MIDI device's output port to the Jamulus MIDI in port (QjackCtl (Linux/Windows), Audio/MIDI Setup (macOS) or whatever you use for managing connections). In Linux you may need to install and launch `a2jmidid` so your device shows up in the MIDI tab in Qjackctl.  For non-JACK Windows, Jamulus will find the MIDI device(s) automatically, but see the `d` option below if more than one MIDI device is connected.
-
-`--ctrlmidich` takes a single argument.  If you omit it, the parameter is ignored.  There are two formats for the argument:
+`--ctrlmidich` takes a single argument. If you omit it, the parameter is ignored. There are two formats for the argument:
 
 1. The legacy definition has one or two numbers in the format:
 
@@ -100,7 +94,7 @@ When using JACK or macOS, make sure you connect your MIDI device's output port t
 
    * `MIDI channel` is required or else the parameter argument is ignored and the feature is not active.  `0` means "any channel", `1`-`16` listen only to MIDI messages on the specified MIDI channel.
 
-   * `offset for first fader` is the first MIDI CC to use to control a Jamulus Channel fader (default 70, which matches the Behringer X-Touch defaults), with all MIDI CCs after that being used; must be a number or else the long form is used.
+   * `offset for first fader` is the first MIDI CC to use to control a Jamulus Channel fader, with all MIDI CCs after that being used; must be a number or else the long form is used.
 
      For example
 
@@ -108,7 +102,7 @@ When using JACK or macOS, make sure you connect your MIDI device's output port t
      --ctrlmidich "0"
      ```
 
-     would listen on all MIDI channels and use MIDI controller 70 to control Jamulus channel 0 fader and so on.  Here's another example:
+     would listen on all MIDI channels and use MIDI controller 0 to control Jamulus channel 0 fader and so on.  Here's another example:
 
      ```
      --ctrlmidich "2;50"
@@ -122,7 +116,7 @@ When using JACK or macOS, make sure you connect your MIDI device's output port t
    [MIDI channel];[control letter][offset](*[count])(;...)
    ```
 
-   * `MIDI channel` is required or else the parameter argument is ignored and the feature is not active.  `0` means "any channel", `1`-`16` listen only to MIDI messages on the specified MIDI channel.
+   * `MIDI channel`
 
    * `control letter` defines which Jamulus Control the MIDI controller number is assigned to:
 
@@ -182,8 +176,6 @@ When using JACK or macOS, make sure you connect your MIDI device's output port t
 	Note that if only one MIDI device is connected, the `d` option is not necessary, as Jamulus will use the device automatically.
 
 	On macOS, Linux or Windows with JACK, the `d` option is accepted if given, but ignored.
-
-*Note*: Jamulus does not provide feedback on the on/off state of buttons, meaning that your controller must keep track and toggle LEDs (if any) to 'on' or 'off' itself, that is, buttons on your MIDI controller need to be set to "toggle" mode. This means that when pressed to 'turn on' a control, it must send a MIDI CC number with a value >=64, and to 'turn off' the control it must send the same CC number with a value <64. You can read your controller's manual to find out how to set this.
 
 ## For Server admins
 


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Updated docs to cover the UI MIDI tab. I moved a number of paragraphs from the `Using --ctrlmidich for MIDI controllers` section to the Software Manual and just left the command line instructions there. It's a feature whose usage initially can be tricky to understand both in the UI and when using the command line, so it's hard to know what to include/trim from each section.

I'm also not sure about assuming usage of Jack/QjackCtl in Linux or even hand-holding users to make MIDI connections at all for that matter (except perhaps to explain the `d` option for Windows). I'm inclined to think that by providing a standard MIDI-in port that works the same way as any other MIDI-aware application, it's not up to us to explain how to connect to it. Ok, it _helps_, but from the point of view of doc maintenance it might make sense to just limit ourselves to things that are specific to Jamulus. Case in point: Jack/QjackCtl  is gradually becoming obsolete, being replaced by PipeWire, though people will probably continue to use one or the other for some time still. Do we expand the docs to also explain PipeWire, pipewire-jack, etc? It can get messy, fast, and might become outdated at any moment.

I did away with the default offset of 70 (it's gone in the app PR). It's an arbitrary value that was initially hard-coded to cater to a single device and hasn't made sense for a long time.

**Context: Fixes an issue? Related issues**
Related to  #3502

@softins: #1119 may need updating if/when this gets in.

**Status of this Pull Request**
Preliminary version subject to comments.

**What is missing until this pull request can be merged?**
<!-- Does it still need more testing; ... -->


**Does this need translation?**

YES.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
