### PR TITLE
Update actions and use hashFiles for po4a cache key

### DIFF
--- a/.github/workflows/add-lang.yml
+++ b/.github/workflows/add-lang.yml
@@ -34,7 +34,7 @@ jobs:
           fi
 
 # Check out repo:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: next-release
 
@@ -51,11 +51,11 @@ jobs:
 # Check po4a cache. If CACHE_HIT: true, retrieve the cache.
 # If not, install po4a and its dependencies and copy them all to a folder (~/po4a/) to be cached:
       - name: Check for po4a cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-po4a
         with:
           path: "~/po4a"
-          key: ${{ runner.os }}-po4a-0.68
+          key: ${{ runner.os }}-po4a-${{ hashFiles('_po4a-tools/po4a-cache.sh') }}
       - name: Install/retrieve po4a from cache
         env:
           CACHE_HIT: ${{ steps.cache-po4a.outputs.cache-hit }}
@@ -67,7 +67,7 @@ jobs:
 
 # Push changes to 'next-release':
       - name: Push changes to repo
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           branch: next-release
           default_author: github_actions
@@ -75,7 +75,7 @@ jobs:
 
 # Add comment to issue informing of the creation of the language files:
       - name: Add comment to issue
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ env.issue_num }}
           body: |

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -13,10 +13,10 @@ jobs:
       contents: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
 # Paths changes filter. Detects if there's been a change to any files defined in the filter:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ github.ref }}
@@ -26,11 +26,11 @@ jobs:
 
 # Retrieve po4a installation cache or create it if not found:
       - name: Check for po4a cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: cache-po4a
         with:
           path: "~/po4a"
-          key: ${{ runner.os }}-po4a-0.68
+          key: ${{ runner.os }}-po4a-${{ hashFiles('_po4a-tools/po4a-cache.sh') }}
       - name: Install or retrieve po4a from cache
         env:
           CACHE_HIT: ${{steps.cache-po4a.outputs.cache-hit}}
@@ -46,7 +46,7 @@ jobs:
 # This step only runs if a PR is merged:
       - name: Push changes to repo if action triggered on:push and .po files need updating
         if: ${{ ( github.event_name == 'push' && steps.filter.outputs.src_files_changed == 'true' ) || ( github.event_name == 'workflow_dispatch' && steps.filter.outputs.src_files_changed == 'true' ) }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: 'AUTO: Updated .po files'
@@ -66,7 +66,7 @@ jobs:
       - name: Zip Website
         if: ${{ github.event_name == 'pull_request' }}
         run: zip -r ${{ github.workspace }}/website.zip _site/*
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         name: Upload Website
         if: ${{ github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,15 +9,15 @@ jobs:
       contents: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
 # Retrieve po4a installation cache or create it if not found:
       - name: Check for po4a cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: cache-po4a
         with:
           path: "~/po4a"
-          key: ${{ runner.os }}-po4a-0.68
+          key: ${{ runner.os }}-po4a-${{ hashFiles('_po4a-tools/po4a-cache.sh') }}
       - name: Install or retrieve po4a from cache
         env:
           CACHE_HIT: ${{steps.cache-po4a.outputs.cache-hit}}
@@ -26,7 +26,7 @@ jobs:
         run: ./_po4a-tools/po4a-cache.sh
 
 # Paths changes filter. If there's been a change to any files defined in the filter, the step (update .po files) runs:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           base: ${{ github.ref }}
@@ -40,7 +40,7 @@ jobs:
 # This step only runs if a PR is merged:
       - name: Push changes to repo if action triggered on:push and .po files need updating
         if: ${{ steps.filter.outputs.src_files_changed == 'true' }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@v10
         with:
           default_author: github_actions
           message: 'AUTO: Update .po files'
@@ -109,9 +109,9 @@ jobs:
       contents: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: ${{ github.sha }} update from release
-        uses: devmasx/merge-branch@v1.3.1
+        uses: devmasx/merge-branch@v1.4.0
         with:
           type: now
           from_branch: release

--- a/_po4a-tools/po4a-cache.sh
+++ b/_po4a-tools/po4a-cache.sh
@@ -7,7 +7,7 @@ if [[ "$CACHE_HIT" == 'true' ]] ; then
     sudo cp --force --recursive ~/po4a/* /
 else
     sudo apt install -yq gettext libsgmls-perl libyaml-tiny-perl opensp libsyntax-keyword-try-perl libxs-parse-keyword-perl
-    wget -O po4a.deb https://github.com/jamulussoftware/assets/raw/main/po4a/po4a_0.68.deb
+    wget -O po4a.deb https://github.com/jamulussoftware/assets/raw/main/po4a/po4a_0.75.deb
     sudo dpkg -i po4a.deb
 
 if [ -f po4a.deb ] ; then

--- a/_po4a-tools/po4a-update-templates.sh
+++ b/_po4a-tools/po4a-update-templates.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script updates/creates .po files for every language
-# po4a >= 0.63 is required, see https://github.com/mquinson/po4a/releases
+# po4a >= 0.68 is required, see https://github.com/mquinson/po4a/releases
 # You can set the following variables:
 # SRC_DIR: directory for the original documents in English. Files in sub-directories within SRC_DIR are also detected.
 # PO_DIR: directory where the .po files are stored


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
Updated GH actions and switched to using hashfiles for the po4a key.

**Context: Fixes an issue? Related issues**
Addresses #882

**Status of this Pull Request**
The next step would be to update the po4a deb package in the assets repo (it's pretty out of date) and the version number in `po4a-cache.sh`.
*Edit*: Done

**What is missing until this pull request can be merged?**
The list of authorised actions has to be updated in the repo settings, otherwise they can't run.
*Edit*: Done.

Everything seems to be working; updating the version in po4a-cache.sh triggers a new cache and all the actions run as expected.


**Does this need translation?**

No


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [ ] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [ ] I'm sure that this Pull Request goes to the correct branch
