### PR TITLE
Make location of "Release Checklist" source obvious

### DIFF
--- a/contribute/en/Release-Process.md
+++ b/contribute/en/Release-Process.md
@@ -359,7 +359,7 @@ Current state: <!-- Planning|Translations (beta)|Code freeze (rc)|Released -->
 - [ ] Create a milestone for the next minor release in jamulus and jamuluswebsite repos
 - [ ] Change the [Project Tracking Board](https://github.com/orgs/jamulussoftware/projects/5/views/5) to the next release (i.e. change the filter and save the change)
 - [ ] Close the release milestone in both jamulus and jamuluswebsite repos
-- [ ] Update this template in https://jamulus.io/contribute/Release-Process with any improvements if needed.
+- [ ] If needed, make any improvements to the "Release Checklist" in the [source of this document](https://github.com/jamulussoftware/jamuluswebsite/blob/release/contribute/en/Release-Process.md?plain=1).
 - [ ] Unpin and close this issue
 - [ ] Determine if a release retrospective is needed, create on Discussions if required
 ~~~


### PR DESCRIPTION
<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**

Old text:
> - [ ] Update this template in https://jamulus.io/contribute/Release-Process with any improvements if needed.

This does not tell the reader where to go to find the actual thing they need to change, hence it's a layer of obfuscation rather than help.

New text:
> - [ ] If needed, make any improvements to the "Release Checklist" in the [source of this document](https://github.com/jamulussoftware/jamuluswebsite/blob/release/contribute/en/Release-Process.md?plain=1).

The link now goes directly to the source in the website repository

**Context: Fixes an issue? Related issues**

Fixes 1128

**Status of this Pull Request**

Wording as above.

**What is missing until this pull request can be merged?**

Needs review.

**Does this need translation?**

Yes.


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [x] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
