### PR TITLE
Improve home server connection guidance

### DIFF
--- a/_translator-files/po/de/Running-a-Server.po
+++ b/_translator-files/po/de/Running-a-Server.po
@@ -124,7 +124,9 @@ msgstr "Normalerweise liegen die Probleme auf der _Client_-Seite und sollten dor
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Bei der Einrichtung von Servern können jedoch auch verschiedene Probleme auftreten, insbesondere wenn sie über einen Heimanschluss mit geringer Bandbreite betrieben werden. Normalerweise ist das in Ordnung wenn weniger als 5 Teilnehmer verbunden sind. (z.B. 10 Mbit/s down und 1 Mbit/s up). Weitere Informationen zu den Netzwerkanforderungen findest du unter [verschiedene Qualitätseinstellungen hier](Server-Bandwidth)"
 
 #. type: Plain text

--- a/_translator-files/po/es/Running-a-Server.po
+++ b/_translator-files/po/es/Running-a-Server.po
@@ -124,7 +124,9 @@ msgstr "Normalmente, los problemas ocurren en el lado del _Cliente_ y deben solu
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Sin embargo, también pueden surgir problemas al configurar Servidores - sobre todo si se ejecutan en una conexión doméstica con poco ancho de banda. Normalmente funciona bien con menos de 5 personas tocando en una conexión doméstica lenta (por ej. unos 10 Mbit/s de bajada y 1 Mbit/s de subida). Puedes leer más sobre los requisitos de red con [diferentes configuraciones de calidad aquí](Server-Bandwidth)."
 
 #. type: Plain text

--- a/_translator-files/po/fr/Running-a-Server.po
+++ b/_translator-files/po/fr/Running-a-Server.po
@@ -128,7 +128,9 @@ msgstr "Habituellement, les problèmes se situent du côté _Client_ et doivent 
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Cependant, divers problèmes peuvent également survenir lors de la configuration des serveurs, en particulier lorsqu'ils sont exécutés sur une connexion domestique à faible bande passante. Il est généralement acceptable d'avoir moins de 5 musiciens sur une connexion domestique à vitesse plus lente (par exemple, 10 Mbit/s aval et 1 Mbit/s amont). Vous pouvez en savoir plus sur les exigences du réseau sur [différents paramètres de qualité ici](Server-Bandwidth)."
 
 #. type: Plain text

--- a/_translator-files/po/it/Running-a-Server.po
+++ b/_translator-files/po/it/Running-a-Server.po
@@ -127,7 +127,9 @@ msgstr "Di solito, i problemi sono sul lato _Client_ e dovrebbero essere risolti
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Tuttavia, possono sorgere vari problemi anche nella realizzazione dei server, specialmente quando questi vengono eseguiti su connessioni domestiche a bassa velocità. Di solito è meglio non far connettere più di 5 utenti su una connessione a bassa velocità (ad es. 10 Mbit/s in download e 1 Mbit/s in upload). Puoi avere ulteriori informazioni sui requisiti di rete in [diverse impostazioni di qualità qui] (larghezza di banda del server)."
 
 #. type: Plain text

--- a/_translator-files/po/ko-KR/Running-a-Server.po
+++ b/_translator-files/po/ko-KR/Running-a-Server.po
@@ -125,7 +125,9 @@ msgstr "일반적으로 문제는 _Client_ 측에 있으며 거기에서 수정�
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "그러나 특히 낮은 대역폭의 홈 연결에서 실행할 때 서버를 설정할 때 다양한 문제가 발생할 수도 있습니다. 느린 속도의 홈 연결(예: 10Mbit/s 다운 및 1Mbit/s 업)에 5명 미만의 플레이어가 있는 것은 일반적으로 괜찮습니다. 네트워크 요구 사항에 대한 자세한 내용은 [여기에서 다른 품질 설정](Server-Bandwidth)을 참조하세요."
 
 #. type: Plain text

--- a/_translator-files/po/nb-NO/Running-a-Server.po
+++ b/_translator-files/po/nb-NO/Running-a-Server.po
@@ -121,7 +121,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr ""
 
 #. type: Plain text

--- a/_translator-files/po/nl/Running-a-Server.po
+++ b/_translator-files/po/nl/Running-a-Server.po
@@ -122,7 +122,9 @@ msgstr "Meestal bevinden problemen zich aan de _client_ kant en moeten daar word
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Er kunnen echter ook verschillende problemen optreden bij het instellen van servers, vooral wanneer deze op een thuisverbinding met lage bandbreedte worden uitgevoerd. Het is meestal prima om minder dan 5 spelers op een tragere thuisverbinding te hebben (bijvoorbeeld 10 Mbit/s down en 1 Mbit/s up). Je kunt meer lezen over netwerkvereisten bij [verschillende kwaliteitsinstellingen hier](Server-Bandwidth)."
 
 #. type: Plain text

--- a/_translator-files/po/pt-BR/Running-a-Server.po
+++ b/_translator-files/po/pt-BR/Running-a-Server.po
@@ -125,7 +125,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr ""
 
 #. type: Plain text

--- a/_translator-files/po/pt-PT/Running-a-Server.po
+++ b/_translator-files/po/pt-PT/Running-a-Server.po
@@ -126,7 +126,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr ""
 
 #. type: Plain text

--- a/_translator-files/po/ru/Running-a-Server.po
+++ b/_translator-files/po/ru/Running-a-Server.po
@@ -123,7 +123,9 @@ msgstr "Обычно проблемы возникают на стороне _к
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Однако при настройке серверов могут возникнуть различные проблемы - особенно если они работают на домашнем соединении с низкой пропускной способностью. Обычно при низкоскоростном домашнем соединении (например, 10 Мбит/с вниз и 1 Мбит/с вверх) количество игроков не превышает 5. Подробнее о требованиях к сети вы можете прочитать в разделе [различные настройки качества здесь](Пропускная способность сервера)."
 
 #. type: Plain text

--- a/_translator-files/po/sv-SE/Running-a-Server.po
+++ b/_translator-files/po/sv-SE/Running-a-Server.po
@@ -124,7 +124,9 @@ msgstr "Vanligtvis är problemen på _klient_ sidan och bör åtgärdas där. Ko
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "Dock kan olika problem också uppstå vid uppsättning av servrar, särskilt när de körs på en hemanslutning med låg bandbredd. Det är vanligtvis okej att ha färre än 5 spelare på en långsammare hemanslutning (t.ex. 10 Mbit/s nedströms och 1 Mbit/s uppströms). Du kan läsa mer om nätverkskrav vid [olika kvalitetsinställningar här](Server-Bandwidth)."
 
 #. type: Plain text

--- a/_translator-files/po/th/Running-a-Server.po
+++ b/_translator-files/po/th/Running-a-Server.po
@@ -121,7 +121,7 @@ msgstr ""
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr ""
 
 #. type: Plain text

--- a/_translator-files/po/zh-CN/Running-a-Server.po
+++ b/_translator-files/po/zh-CN/Running-a-Server.po
@@ -128,7 +128,9 @@ msgstr "通常，问题在 _Client_ 端，应该在那里解决。如果需要�
 
 #. type: Plain text
 #: ../wiki/en/Running-a-Server.md:37
-msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+#, fuzzy
+#| msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
+msgid "However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth)."
 msgstr "但是，在设置服务器时也会出现各种问题——尤其是在低带宽家庭连接上运行时。在较慢的家庭连接(例如 10 Mbit/s 下行和 1 Mbit/s 上行)上拥有少于 5 个玩家通常是可以的。您可以在 [这里的不同质量设置](Server-Bandwidth) 阅读有关网络要求的更多信息。"
 
 #. type: Plain text

--- a/wiki/en/Running-a-Server.md
+++ b/wiki/en/Running-a-Server.md
@@ -33,7 +33,7 @@ Using a public Server might introduce you to strangers. If you want an undisturb
 
 Usually, problems are on the _Client_ side and should be fixed there. Have a look at the [Troubleshooting page](/wiki/Client-Troubleshooting) if needed.
 
-However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It's usually fine to have less than 5 players on a slower-speed home connection (eg 10 Mbit/s down and 1 Mbit/s up). You can read more about network requirements at [different quality settings here](Server-Bandwidth).
+However, various problems can also arise when setting up Servers - especially when run on a low-bandwidth home connection. It can work to have less than 5 players on a slower-speed home connection. A wireless internet connection is discouraged for a server in your home, while a fiber connection should work well. You can read more about network requirements at [different quality settings here](Server-Bandwidth).
 
 Consider using a cloud host, not your home internet connection, to get better ping times if you're having problems.
 


### PR DESCRIPTION
## Summary
- Removes specific bandwidth numbers (10 Mbit/s down / 1 Mbit/s up)
- Discourages wireless connections for home servers
- Notes that fiber connections should work well

## Test plan
- [ ] Review the changed sentence in `wiki/en/Running-a-Server.md` for accuracy and tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)