### PR TITLE
Update 2021-09-09-Inputs.md

### DIFF
--- a/_posts/2021-09-09-Inputs.md
+++ b/_posts/2021-09-09-Inputs.md
@@ -8,10 +8,11 @@ heading: "Points to note about inputs"
 
 ## Points to note about inputs
 
-- If you want to connect 2 or more sources (e.g. voice + synth + guitar), it is important to note that Jamulus currently handles only 2 input channels (L/R). So the hardware being used must provide a mixed-down stereo output to Jamulus. Alternatively, run two instances of Jamulus, if your hardware supports it, or use virtual audio inputs to Jamulus for each hardware input.
-- Audio interfaces generally output a mixed signal on their analogue output, but separate signals (1 per source) on their digital output (USB/FireWire/Thunderbolt).
-- Mixers generally only output mixed-down signals on their analogue output.
-- Mixers with USB/FireWire/Thunderbolt generally output a mixed-down signal on their **analogue** output AND separate signals only (no mixed-down signal) on their **digital** output.
-- A few Mixers with USB/FireWire/Thunderbolt will either send **only** a mixed-down signal to the **digital** output (small/budget mixers), or else also ADD a stereo mixed-down signal to the separate signals on the digital output.
+- If you want to connect many sources (e.g. voice + synth + guitar), it is important to note that Jamulus currently handles only 2 input channels (either Mono 1 and 2 or Stereo L/R). So the hardware (audio interfaces or mixers) being used must provide a mixed-down 2 channels output to Jamulus. Alternatively, run more instances of Jamulus, if your hardware/software supports it, or use virtual audio inputs (1) to Jamulus for each hardware input.
+- Audio Interfaces generally output a mixed signal on their **analogue** output, but separate signals (1 per source) on their **digital** output (USB/FireWire/Thunderbolt).
+- Mixers generally only output mixed-down signals on their **analogue** output.
+- Mixers with USB/FireWire/Thunderbolt generally output a mixed-down signal on their **analogue** and **digital** output.
+- A few Mixers with USB/FireWire/Thunderbolt (sometimes called "mixerface") can send a stereo mixed-down signal AND/OR separate signals on the **digital** output.
+(1) You could use a DAW with virtual routing between your hardware and Jamulus (example : Reaper with ReaRoute).
 
 _(Thanks to [pcar75](https://github.com/pcar75) for this information)_

--- a/_posts/2021-09-09-Inputs.md
+++ b/_posts/2021-09-09-Inputs.md
@@ -8,7 +8,7 @@ heading: "Points to note about inputs"
 
 ## Points to note about inputs
 
-- If you want to connect many sources (e.g. voice + synth + guitar), it is important to note that Jamulus currently handles only 2 input channels (either Mono 1 and 2 or Stereo L/R). So the hardware (audio interfaces or mixers) being used must provide a mixed-down 2 channels output to Jamulus. Alternatively, run more instances of Jamulus, if your hardware/software supports it, or use virtual audio inputs (1) to Jamulus for each hardware input.
+- If you want to connect many sources (e.g. voice + synth + guitar), it is important to note that Jamulus currently handles only 2 input channels (either Mono 1 and 2 or Stereo L/R). So the hardware (audio interfaces or mixers) being used must provide a mixed-down 2 channels output to Jamulus. Alternatively, run more instances of Jamulus (if your hardware/software supports it), or use virtual audio inputs (1) to Jamulus for each hardware input.
 - Audio Interfaces generally output a mixed signal on their **analogue** output, but separate signals (1 per source) on their **digital** output (USB/FireWire/Thunderbolt).
 - Mixers generally only output mixed-down signals on their **analogue** output.
 - Mixers with USB/FireWire/Thunderbolt generally output a mixed-down signal on their **analogue** and **digital** output.


### PR DESCRIPTION
In the Knowledgebase section of the Jamulus website ( jamuluswebsite / _posts / 2021-09-09-Inputs.md ), I recently realized that my description for "Mixers with USB/..."   was in error.  I have reformulated the post to correct it  My apologies to anyone it may have inconvenienced.
Thanks.

<!-- Thank you for working on Jamulus and opening a Pull Request! Please fill in the following to make the review process straightforward -->

**Short description of changes**
<!--  correction  -->

**Context: Fixes an issue? Related issues**
<!-- Misleading paragraph Mixer with USB/...  Generally these mixers do not output separate source signals ; only mixed-down signals-->

**Status of this Pull Request**
<!-- This might be edited by maintainers. -->
<!-- Proof of concept (not to be merged soon); Working implementation; ... -->

**What is missing until this pull request can be merged?**
<!-- None -->


**Does this need translation?**

<!-- YES -->


## Checklist
<!-- Please tick the check boxes when done by replacing the space by an x, e.g. [x]. -->
- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors. <!-- GitHub doesn't run these checks for new contributors automatically. -->
- [x] I'm sure that this Pull Request goes to the correct branch
