### PR TITLE
Document the `-c` port-reachability limitation

### DIFF
--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -1,6 +1,6 @@
 - `-M` or `--mutestream`  Prevent others on a server from hearing what I play
 - `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)
--  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`. `-c` connects directly, so the server's port must already be reachable from your computer — you may need to open it in the router, cloud firewall/security group, and/or OS firewall. (Selecting a server from the directory list in the GUI opens the port for you; `-c` does not, whether or not the server is listed.)
+-  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`. `-c` connects directly, so the server's port must already be reachable from your computer — the server's operator may need to open the port in the router, cloud firewall/security group, and/or OS firewall. (Selecting a server from the directory list in the GUI opens the port for you; `-c` does not, whether or not the server is listed.)
 -  `-j` or `--nojackconnect`  Disable auto JACK connections
 -  `--ctrlmidich`  MIDI channel to listen on, Jamulus control + MIDI control number and count of consecutive CC numbers (or Jamulus channels), pick-up mode, device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;u][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name

--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -1,6 +1,6 @@
 - `-M` or `--mutestream`  Prevent others on a server from hearing what I play
 - `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)
--  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`
+-  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`. `-c` connects directly, so the server's port must already be reachable from your computer — you may need to open it in the router, cloud firewall/security group, and/or OS firewall. (Selecting a server from the directory list in the GUI opens the port for you; `-c` does not, whether or not the server is listed.)
 -  `-j` or `--nojackconnect`  Disable auto JACK connections
 -  `--ctrlmidich`  MIDI channel to listen on, Jamulus control + MIDI control number and count of consecutive CC numbers (or Jamulus channels), pick-up mode, device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;u][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name

--- a/wiki/en/Include-Client-Commands.md
+++ b/wiki/en/Include-Client-Commands.md
@@ -1,6 +1,6 @@
 - `-M` or `--mutestream`  Prevent others on a server from hearing what I play
 - `--mutemyown` Prevent me from hearing what I play in the server mix (headless only)
--  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`. `-c` connects directly, so the server's port must already be reachable from your computer — the server's operator may need to open the port in the router, cloud firewall/security group, and/or OS firewall. (Selecting a server from the directory list in the GUI opens the port for you; `-c` does not, whether or not the server is listed.)
+-  `-c` or `--connect`  Connect to given server address on startup, format `address[:port]`. `-c` connects directly, so the server's port must already be reachable from your computer - the server's operator may need to open the port in the router, cloud firewall/security group, and/or OS firewall. (Selecting a server from the directory list in the GUI opens the port for you; `-c` does not, whether or not the server is listed.)
 -  `-j` or `--nojackconnect`  Disable auto JACK connections
 -  `--ctrlmidich`  MIDI channel to listen on, Jamulus control + MIDI control number and count of consecutive CC numbers (or Jamulus channels), pick-up mode, device selection option. Format: `channel[;fn[*n]][;pn[*n]][;sn[*n]][;mn[*n]][;on][;u][;dDeviceName]` See [Tips & Tricks](Tips-Tricks-More#using---ctrlmidich-for-midi-controllers).
 - `--clientname`  Window title and JACK client name


### PR DESCRIPTION
**Short description of changes**

Expands the `-c` / `--connect` entry in `Include-Client-Commands.md` with concise guidance on why it can fail to reach a server that the GUI reaches fine.

`-c` connects directly to the given address. Unlike selecting a server from the directory list in the GUI, it does not have a directory open the server's port, so the port must already be reachable from the client — which may require opening it in the router, cloud firewall/security group, and/or OS firewall. This holds whether or not the server is listed in a directory. Today the docs don't mention this and the failure is silent and confusing.

**Context: Fixes an issue? Related issues**

Relates to jamulussoftware/jamuluswebsite#1122. This documents the current behaviour and its limitation; it intentionally does **not** close #1122, which stays open for the separate discussion of improving `-c` itself (directory-assisted hole-punch), which would land in the Jamulus repo.

**Status of this Pull Request**

Working implementation.

**What is missing until this pull request can be merged?**

Nothing outstanding — documentation only, single-line change to one English file. Ready for review.

**Does this need translation?**

YES (new English string) — hence this PR targets the `next-release` branch.

## Checklist

- [x] I've verified that this Pull Request follows the [general code principles](https://github.com/jamulussoftware/jamulus/blob/main/CONTRIBUTING.md#jamulus-projectsource-code-general-principles)
- [ ] I waited some time after this Pull Request was opened and all GitHub checks completed without errors.
- [x] I'm sure that this Pull Request goes to the correct branch
