### PR TITLE
CI: pin jekyll/builder image and install gems from the lockfile

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -62,7 +62,7 @@ jobs:
         run: |
           docker run \
           -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-          jekyll/builder:latest /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && jekyll build --future"
+          jekyll/builder:4.4.1 /bin/bash -c "chmod a+w /srv/jekyll/Gemfile.lock && chmod 777 /srv/jekyll && bundle install && bundle exec jekyll build --future"
       - name: Zip Website
         if: ${{ github.event_name == 'pull_request' }}
         run: zip -r ${{ github.workspace }}/website.zip _site/*


### PR DESCRIPTION
## Problem

`jekyll_site_ci` is currently failing on every PR (e.g. #1145), in the **Build the site in the jekyll/builder container** step:

```
Bundler::Definition#materialize': Could not find jekyll-4.3.3, jekyll-polyglot-1.8.1,
jekyll-minifier-0.1.10, jekyll-paginate-v2-3.0.0, ... in locally installed gems
```

while the container is running Jekyll 4.4.1.

## Root cause

The build ran inside the floating `jekyll/builder:latest` image and relied entirely on the gems baked into that image (there was no `bundle install`). Docker Hub recently republished `latest` as **Jekyll 4.4.1**, whose bundled gem set no longer matches the committed `Gemfile.lock` (Jekyll 4.3.3, jekyll-polyglot 1.8.1, ...). Bundler can't reconcile the lockfile against the image's preinstalled gems, so it fails in `Definition#materialize` and `jekyll build` exits 1.

This is environmental, not a defect in any page content — it broke all open PRs at once when the upstream tag moved. (There is no `jekyll/builder:4.3.3` tag on Docker Hub, so the lockfile could no longer be satisfied by `latest`.)

## Fix

- Pin the image to a fixed tag (`jekyll/builder:4.4.1`) so it can no longer silently drift.
- Run `bundle install && bundle exec jekyll build` so the committed `Gemfile.lock` is authoritative and the image only needs to supply Ruby + Bundler.

This unblocks #1145 and the other open PRs. Supersedes the empty WIP #1155.

## Note

An alternative would be to regenerate `Gemfile.lock` against 4.4.1 and keep the fast no-install path, but that requires confirming the plugins (jekyll-polyglot / jekyll-minifier / jekyll-paginate-v2) are 4.4-compatible. Installing from the lockfile is the lower-risk unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)